### PR TITLE
Index support tweaks zhou

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,24 +6,43 @@ The API documentation is available on SmartAPI at https://smart-api.info/ui/7aaf
 
 ## Search endpoint and group access check
 
-The search endpoint for each deployment environment:
+The search-api base URL for each deployment environment:
 
-- DEV: `https://search-api.dev.hubmapconsortium.org/search`
-- TEST: `https://search-api.test.hubmapconsortium.org/search`
+- DEV: `https://search-api.dev.hubmapconsortium.org`
+- TEST: `https://search-api.test.hubmapconsortium.org`
+- PROD: `https://search.api.hubmapconsortium.org`
 
-Both HTTP `GET` and `POST` methods are supported. Due to data access restriction, indexed entries are protected and calls to the above endpoint require the `Authorization` header with the Bearer token (globus nexus token) along with the search query JSON body. There are three cases when making a search call:
+## Request endpoints
 
-### Case 1: Missing/invalid/expired token
+### Get all supported indices
 
-If a token is missing, invalid or expired, an error message with 401 status code will be returned. 
+This endpoint returns a list of supported indices, no globus token is required to make the request.
 
-### Case 2: Valid token without the right group access
+````
+GET /indices
+````
 
-In the case that the token is valid **BUT** the owner of this token doesn't have the right group access, a 403 error message will be returned.
+### Search without specifiing an index
 
-### Case 3: Valid token with right group access
+The Authorization header with globus token is optional
 
-With a valid token (that represents a user who has the correct group access to the indexed data), **ALL** the user specified search query DSL (Domain Specific Language) detail will be passed to the Elasticsearch just like making queries against the Elasticsearch directly, and the search hits results will be returned. Elasticsearch will also return any error messges if the JSON query is misformatted.
+````
+GET/POST /search
+````
+
+### Search against a specified index
+
+The Authorization header with globus token is optional
+
+````
+GET/POST /<index>/search
+````
+Due to data access restriction, indexed entries are protected and calls to the above endpoints require the `Authorization` header with the Bearer token (globus nexus token) along with the search query JSON body. There are three cases when making a search call:
+
+- Case #1: Authorization header is missing, default to use the `entities` index with only public data entries. 
+- Case #2: Authorization header with valid token, but the member doesn't belong to the HuBMAP-Read group, direct the call to use the `entities` index with only public data entries. 
+- Case #3: Authorization header presents but with invalid or expired token, return 401 (if someone is sending a token, they might be expecting more than public stuff).
+- Case #4: Authorization header presents with a valid token that has the group access, **ALL** the user specified search query DSL (Domain Specific Language) detail will be passed to the Elasticsearch just like making queries against the Elasticsearch directly.
 
 NOTE: currently, the Search API doesn't support comma-separated list or wildcard expression of index names in the URL path used to limit the request.
 

--- a/src/instance/app.cfg.example
+++ b/src/instance/app.cfg.example
@@ -8,9 +8,8 @@ ELASTICSEARCH_URL = ''
 PUBLIC_INDEX_PREFIX = 'hm_public_'
 PRIVATE_INDEX_PREFIX = 'hm_consortium_'
 
-# Default index name for `/search` compability, can NOT be empty
-DEFAULT_PUBLIC_INDEX = 'hm_public_entities'
-DEFAULT_PRIVATE_INDEX = 'hm_consortium_entities'
+# Default index (without prefix) name for `/search` compability, can NOT be empty
+DEFAULT_INDEX_WITHOUT_PREFIX = 'entities'
 
 # Entity-API service
 # Default value works with docker deployment on localhost, dev, test, and prod
@@ -24,13 +23,14 @@ APP_CLIENT_SECRET = ''
 # Globus Hubmap-Read group UUID
 GLOBUS_HUBMAP_READ_GROUP_UUID = '5777527e-ec11-11e8-ab41-0af86edb4424'
 
+# Open: Only entities can open to the public
+# All: All entities
+# original: directly from neo4j
+# transformed: transformed by portal transform method
 INDICES = """{
             'hm_public_entities': ('Open','original'),
             'hm_consortium_entities': ('All', 'original'),
             'hm_public_portal': ('Open', 'transformed'),
             'hm_consortium_portal': ('All', 'transformed')
             }"""
-# Open: Only entities can open to the public
-# All: All entities
-# original: directly from neo4j
-# transformed: transformed by portal transform method
+


### PR DESCRIPTION
- Only return filtered indices that exist as pairs in ES
- Hide the prefix to end users
- Determine the target index based on the user-provided index (without prefix)
- Use only one default index
- Updated instructions