### PR TITLE
Mccalluc/backward compatibility

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/opt/anaconda3/envs/search-api/bin/python"
+}

--- a/src/elasticsearch/addl_index_transformations/portal/.flake8
+++ b/src/elasticsearch/addl_index_transformations/portal/.flake8
@@ -1,3 +1,4 @@
 [flake8]
-ignore = E501 # line too long
+ignore = E501, # line too long
+    W503 # line break before binary operator
 exclude = search-schema/*

--- a/src/elasticsearch/addl_index_transformations/portal/.flake8
+++ b/src/elasticsearch/addl_index_transformations/portal/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+ignore = E501 # line too long
+exclude = search-schema/*

--- a/src/elasticsearch/addl_index_transformations/portal/__init__.py
+++ b/src/elasticsearch/addl_index_transformations/portal/__init__.py
@@ -11,6 +11,9 @@ from yaml import dump as dump_yaml, safe_load as load_yaml
 from elasticsearch.addl_index_transformations.portal.translate import (
     translate, TranslationException
 )
+from elasticsearch.addl_index_transformations.portal.add_everything import (
+    add_everything
+)
 
 
 def transform(doc, batch_id='unspecified'):
@@ -59,6 +62,7 @@ def transform(doc, batch_id='unspecified'):
     except TranslationException as e:
         logging.error(f'Batch {batch_id}; UUID {doc["uuid"]}: {e}')
         return None
+    add_everything(doc_copy)
     return doc_copy
 
 

--- a/src/elasticsearch/addl_index_transformations/portal/__init__.py
+++ b/src/elasticsearch/addl_index_transformations/portal/__init__.py
@@ -15,11 +15,6 @@ from elasticsearch.addl_index_transformations.portal.translate import (
 
 def transform(doc, batch_id='unspecified'):
     '''
-    >>> transform({})
-    Traceback (most recent call last):
-    ...
-    KeyError: 'entity_type'
-
     >>> from pprint import pprint
     >>> pprint(transform({
     ...    'entity_type': 'Donor',
@@ -37,11 +32,15 @@ def transform(doc, batch_id='unspecified'):
     ...    'descendants': 'xxx',
     ...    'THE_SPANISH_INQUISITION': 'No one expects'
     ... }))
-    {'access_group': 'xxx',
+    {'THE_SPANISH_INQUISITION': 'No one expects',
+     'access_group': 'xxx',
      'ancestor_ids': 'xxx',
+     'ancestors': 'xxx',
      'create_timestamp': 1575489509656,
      'created_by_user_displayname': 'xxx',
      'created_by_user_email': 'xxx',
+     'descendant_ids': 'xxx',
+     'descendants': 'xxx',
      'entity_type': 'Donor',
      'group_name': 'xxx',
      'group_uuid': 'xxx',
@@ -67,7 +66,9 @@ _data_dir = Path(__file__).parent / 'search-schema' / 'data'
 
 
 def _clean(doc):
-    _map(doc, _simple_clean)
+    return doc
+    # TODO: Reenable.
+    # _map(doc, _simple_clean)
 
 
 def _map(doc, clean):
@@ -82,25 +83,26 @@ def _map(doc, clean):
         for sample in doc['source_sample']:
             _map(sample, clean)
 
+# TODO: Reenable this when we have time, and can make sure we don't need these fields.
+#
+# def _simple_clean(doc):
+#     schema = _get_schema(doc)
+#     allowed_props = schema['properties'].keys()
+#     keys = list(doc.keys())
+#     for key in keys:
+#         if key not in allowed_props:
+#             del doc[key]
 
-def _simple_clean(doc):
-    schema = _get_schema(doc)
-    allowed_props = schema['properties'].keys()
-    keys = list(doc.keys())
-    for key in keys:
-        if key not in allowed_props:
-            del doc[key]
-
-    # Not used in portal:
-    for unused_key in [
-        'ancestors',  # ancestor_ids *is* used in portal.
-        'descendants',
-        'descendant_ids',
-        'hubmap_display_id',  # Only used in ingest.
-        'rui_location'
-    ]:
-        if unused_key in doc:
-            del doc[unused_key]
+#     # Not used in portal:
+#     for unused_key in [
+#         'ancestors',  # ancestor_ids *is* used in portal.
+#         'descendants',
+#         'descendant_ids',
+#         'hubmap_display_id',  # Only used in ingest.
+#         'rui_location'
+#     ]:
+#         if unused_key in doc:
+#             del doc[unused_key]
 
 
 _schemas = {

--- a/src/elasticsearch/addl_index_transformations/portal/__init__.py
+++ b/src/elasticsearch/addl_index_transformations/portal/__init__.py
@@ -20,37 +20,46 @@ def transform(doc, batch_id='unspecified'):
     '''
     >>> from pprint import pprint
     >>> pprint(transform({
-    ...    'entity_type': 'Donor',
+    ...    'entity_type': 'dataset',
+    ...    'origin_sample': {
+    ...        'organ': 'LY01'
+    ...    },
     ...    'create_timestamp': 1575489509656,
-    ...    'created_by_user_displayname': 'xxx',
-    ...    'created_by_user_email': 'xxx',
-    ...    'group_name': 'xxx',
-    ...    'group_uuid': 'xxx',
-    ...    'last_modified_timestamp': '1575489509656',
-    ...    'uuid': 'xxx',
-    ...    'access_group': 'xxx',
-    ...    'ancestor_ids': 'xxx',
-    ...    'ancestors': 'xxx',
-    ...    'descendant_ids': 'xxx',
-    ...    'descendants': 'xxx',
-    ...    'THE_SPANISH_INQUISITION': 'No one expects'
+    ...    'ancestor_ids': ['1234', '5678'],
+    ...    'donor': {
+    ...        "metadata": {
+    ...             "organ_donor_data": [
+    ...                 {
+    ...                     "data_type": "Nominal",
+    ...                     "grouping_concept_preferred_term":
+    ...                         "Gender finding",
+    ...                     "preferred_term": "Masculine gender"
+    ...                 }
+    ...             ]
+    ...         }
+    ...    }
     ... }))
-    {'THE_SPANISH_INQUISITION': 'No one expects',
-     'access_group': 'xxx',
-     'ancestor_ids': 'xxx',
-     'ancestors': 'xxx',
+    {'ancestor_ids': ['1234', '5678'],
      'create_timestamp': 1575489509656,
-     'created_by_user_displayname': 'xxx',
-     'created_by_user_email': 'xxx',
-     'descendant_ids': 'xxx',
-     'descendants': 'xxx',
-     'entity_type': 'Donor',
-     'group_name': 'xxx',
-     'group_uuid': 'xxx',
-     'last_modified_timestamp': '1575489509656',
+     'donor': {'mapped_metadata': {'gender': 'Masculine gender'},
+               'metadata': {'organ_donor_data': [{'data_type': 'Nominal',
+                                                  'grouping_concept_preferred_term': 'Gender '
+                                                                                     'finding',
+                                                  'preferred_term': 'Masculine '
+                                                                    'gender'}]}},
+     'entity_type': 'dataset',
+     'everything': ['1234',
+                    '1575489509656',
+                    '2019-12-04 19:58:29',
+                    '5678',
+                    'Gender finding',
+                    'LY01',
+                    'Lymph Node',
+                    'Masculine gender',
+                    'Nominal',
+                    'dataset'],
      'mapped_create_timestamp': '2019-12-04 19:58:29',
-     'mapped_last_modified_timestamp': '2019-12-04 19:58:29',
-     'uuid': 'xxx'}
+     'origin_sample': {'mapped_organ': 'Lymph Node', 'organ': 'LY01'}}
 
     '''
     doc_copy = deepcopy(doc)

--- a/src/elasticsearch/addl_index_transformations/portal/__init__.py
+++ b/src/elasticsearch/addl_index_transformations/portal/__init__.py
@@ -39,13 +39,15 @@ def transform(doc, batch_id='unspecified'):
     ... }))
     {'access_group': 'xxx',
      'ancestor_ids': 'xxx',
-     'create_timestamp': '2019-12-04 19:58:29',
+     'create_timestamp': 1575489509656,
      'created_by_user_displayname': 'xxx',
      'created_by_user_email': 'xxx',
      'entity_type': 'Donor',
      'group_name': 'xxx',
      'group_uuid': 'xxx',
-     'last_modified_timestamp': '2019-12-04 19:58:29',
+     'last_modified_timestamp': '1575489509656',
+     'mapped_create_timestamp': '2019-12-04 19:58:29',
+     'mapped_last_modified_timestamp': '2019-12-04 19:58:29',
      'uuid': 'xxx'}
 
     '''

--- a/src/elasticsearch/addl_index_transformations/portal/add_everything.py
+++ b/src/elasticsearch/addl_index_transformations/portal/add_everything.py
@@ -1,6 +1,49 @@
-# Note: The goal is to support free-text search.
+# Note: The goal is to support free-text search across all fields.
 # This is a stop-gap until mappings can be specified, and copy_to used:
 # https://github.com/hubmapconsortium/search-api/issues/63
 
+
 def add_everything(doc):
-    doc['everything'] = []
+    '''
+    >>> doc = {
+    ...   'a': {
+    ...     'b': {
+    ...       'c': ['deep', 'deep']
+    ...     }
+    ...   }
+    ... }
+    >>> add_everything(doc)
+    >>> doc
+    {'a': {'b': {'c': ['deep', 'deep']}}, 'everything': ['deep']}
+
+    '''
+    everything = set(_get_nested_values(doc))
+    # Sort for stability in tests;
+    # Could be removed if it's a performance hit.
+    doc['everything'] = sorted(everything)
+
+
+def _get_nested_values(input):
+    '''
+    >>> doc = {
+    ...   'a': {
+    ...     'b0': {
+    ...       'c': ['deep', 'deep!']
+    ...     },
+    ...     'b1': 'deep'
+    ...   },
+    ...   'xyz': 'shallow',
+    ...   'number': 123
+    ... }
+    >>> list(_get_nested_values(doc))
+    ['deep', 'deep!', 'deep', 'shallow', '123']
+
+    '''
+    if isinstance(input, dict):
+        for value in input.values():
+            yield from _get_nested_values(value)
+    elif isinstance(input, list):
+        for value in input:
+            yield from _get_nested_values(value)
+    else:
+        yield str(input)

--- a/src/elasticsearch/addl_index_transformations/portal/add_everything.py
+++ b/src/elasticsearch/addl_index_transformations/portal/add_everything.py
@@ -1,0 +1,6 @@
+# Note: The goal is to support free-text search.
+# This is a stop-gap until mappings can be specified, and copy_to used:
+# https://github.com/hubmapconsortium/search-api/issues/63
+
+def add_everything(doc):
+    doc['everything'] = []

--- a/src/elasticsearch/addl_index_transformations/portal/test.sh
+++ b/src/elasticsearch/addl_index_transformations/portal/test.sh
@@ -15,6 +15,6 @@ end flake8
 start doctests
 cd ../../..
 ls elasticsearch/addl_index_transformations/portal/*.py \
-  | xargs python -m doctest -v
+  | xargs python -m doctest
 cd -
 end doctests

--- a/src/elasticsearch/addl_index_transformations/portal/test.sh
+++ b/src/elasticsearch/addl_index_transformations/portal/test.sh
@@ -14,7 +14,8 @@ end flake8
 
 start doctests
 cd ../../..
-ls elasticsearch/addl_index_transformations/portal/*.py \
-  | xargs python -m doctest
+for F in elasticsearch/addl_index_transformations/portal/*.py; do
+  python -m doctest $F
+done
 cd -
 end doctests

--- a/src/elasticsearch/addl_index_transformations/portal/test.sh
+++ b/src/elasticsearch/addl_index_transformations/portal/test.sh
@@ -9,7 +9,7 @@ cd `dirname $0`
 
 start flake8
 flake8 \
-  || die "Try: autopep8 --in-place --aggressive -r ."
+  || die "Try: autopep8 --in-place --aggressive -r $PWD"
 end flake8
 
 start doctests

--- a/src/elasticsearch/addl_index_transformations/portal/translate.py
+++ b/src/elasticsearch/addl_index_transformations/portal/translate.py
@@ -31,7 +31,7 @@ def _map(doc, key, map):
     # The recursion is usually not needed...
     # but better to do it everywhere than to miss one case.
     if key in doc:
-        doc[key] = map(doc[key])
+        doc[f'mapped_{key}'] = map(doc[key])
     if 'donor' in doc:
         _map(doc['donor'], key, map)
     if 'origin_sample' in doc:
@@ -47,11 +47,11 @@ def _translate_status(doc):
     '''
     >>> doc = {'status': 'NEW'}
     >>> _translate_status(doc); doc
-    {'status': 'New'}
+    {'status': 'NEW', 'mapped_status': 'New'}
 
     >>> doc = {'status': 'qa'}
     >>> _translate_status(doc); doc
-    {'status': 'QA'}
+    {'status': 'qa', 'mapped_status': 'QA'}
 
     >>> doc = {'status': 'xyz'}
     >>> _translate_status(doc)
@@ -88,8 +88,10 @@ def _translate_timestamp(doc):
     >>> _translate_timestamp(doc);
     >>> from pprint import pprint
     >>> pprint(doc)
-    {'create_timestamp': '2019-12-04 19:58:29',
-     'last_modified_timestamp': '2020-05-20 23:34:23'}
+    {'create_timestamp': '1575489509656',
+     'last_modified_timestamp': 1590017663118,
+     'mapped_create_timestamp': '2019-12-04 19:58:29',
+     'mapped_last_modified_timestamp': '2020-05-20 23:34:23'}
 
     '''
     _map(doc, 'create_timestamp', _timestamp_map)
@@ -109,11 +111,11 @@ def _translate_organ(doc):
     '''
     >>> doc = {'organ': 'LY01'}
     >>> _translate_organ(doc); doc
-    {'organ': 'Lymph Node'}
+    {'organ': 'LY01', 'mapped_organ': 'Lymph Node'}
 
     >>> doc = {'origin_sample': {'organ': 'RK'}}
     >>> _translate_organ(doc); doc
-    {'origin_sample': {'organ': 'Kidney (Right)'}}
+    {'origin_sample': {'organ': 'RK', 'mapped_organ': 'Kidney (Right)'}}
 
     >>> doc = {'origin_sample': {'organ': 'ZZ'}}
     >>> _translate_organ(doc)
@@ -143,7 +145,7 @@ def _translate_specimen_type(doc):
     '''
     >>> doc = {'specimen_type': 'fresh_frozen_tissue'}
     >>> _translate_specimen_type(doc); doc
-    {'specimen_type': 'Fresh frozen tissue'}
+    {'specimen_type': 'fresh_frozen_tissue', 'mapped_specimen_type': 'Fresh frozen tissue'}
 
     >>> doc = {'specimen_type': 'xyz'}
     >>> _translate_specimen_type(doc)
@@ -204,12 +206,11 @@ def _translate_donor_metadata(doc):
     ...     }
     ... }
     >>> _translate_donor_metadata(doc)
+    >>> len(doc['metadata']['organ_donor_data'])
+    4
     >>> from pprint import pprint
-    >>> pprint(doc)
-    {'metadata': {'age': 58.0,
-                  'bmi': 22.0,
-                  'gender': 'Masculine gender',
-                  'race': 'African race'}}
+    >>> pprint(doc['mapped_metadata'])
+    {'age': 58.0, 'bmi': 22.0, 'gender': 'Masculine gender', 'race': 'African race'}
 
     >>> doc = {
     ...     "metadata": {
@@ -235,6 +236,7 @@ def _donor_metadata_map(metadata):
         'Gender finding': 'gender',
         'Racial group': 'race'
     }
+    mapped_metadata = {}
     if 'organ_donor_data' in metadata:
         for kv in metadata['organ_donor_data']:
             term = kv['grouping_concept_preferred_term']
@@ -246,6 +248,5 @@ def _donor_metadata_map(metadata):
                 if kv['data_type'] == 'Nominal'
                 else float(kv['data_value'])
             )
-            metadata[k] = v
-        del metadata['organ_donor_data']
-    return metadata
+            mapped_metadata[k] = v
+    return mapped_metadata

--- a/src/elasticsearch/addl_index_transformations/portal/translate.py
+++ b/src/elasticsearch/addl_index_transformations/portal/translate.py
@@ -187,7 +187,7 @@ def _translate_donor_metadata(doc):
     ...                 "data_value": "58",
     ...                 "grouping_concept_preferred_term":
     ...                     "Current chronological age",
-    ...                 "units": "years"
+    ...                 "units": "months"
     ...             },
     ...             {
     ...                 "data_type": "Numeric",
@@ -210,7 +210,7 @@ def _translate_donor_metadata(doc):
     4
     >>> from pprint import pprint
     >>> pprint(doc['mapped_metadata'])
-    {'age': 58.0, 'bmi': 22.0, 'gender': 'Masculine gender', 'race': 'African race'}
+    {'age': 4.8, 'bmi': 22.0, 'gender': 'Masculine gender', 'race': 'African race'}
 
     >>> doc = {
     ...     "metadata": {
@@ -243,10 +243,13 @@ def _donor_metadata_map(metadata):
             if term not in recognized_terms:
                 raise TranslationException(f'Unexpected term: {term}')
             k = recognized_terms[term]
-            v = (
-                kv['preferred_term']
-                if kv['data_type'] == 'Nominal'
-                else float(kv['data_value'])
-            )
+            if k == 'age' and kv['units'] == 'months':
+                v = round(float(kv['data_value']) / 12, 1)
+            else:
+                v = (
+                    kv['preferred_term']
+                    if kv['data_type'] == 'Nominal'
+                    else float(kv['data_value'])
+                )
             mapped_metadata[k] = v
     return mapped_metadata


### PR DESCRIPTION
@etlds : This doesn't explicitly address anything from the error log you gave me, because I couldn't tie any of the errors there to my code... I'm hoping the improved logging you've put in place will make this easier.

@john-conroy:
- In my first attempt at this, I was aggressively trying to clean up the data, removing fields that were not in the schema, and rewriting others, but I think that was unrealistic. Now, every field in the original doc will be left as is, but where I'm cleaning things up, or expanding an abbreviation, there is a new `mapped_*` field.
- In addition: It will handle ages in months... Pretty sure I saw an instance of that, but haven't tried to relocate. It is also more robust if the names of the grouping terms are changed... but that code should be cleaned up when things settle down.
- and I walk the entire document collecting the values, and create a new multivalued `everything` field with them to support text search. This is not the ideal way of doing this, but we will not be able to specify mappings in Elasticsearch any time soon.