### PR TITLE
Mccalluc/map assay types

### DIFF
--- a/src/elasticsearch/addl_index_transformations/portal/__init__.py
+++ b/src/elasticsearch/addl_index_transformations/portal/__init__.py
@@ -43,7 +43,8 @@ def transform(doc, batch_id='unspecified'):
     ... }))
     {'ancestor_ids': ['1234', '5678'],
      'create_timestamp': 1575489509656,
-     'doc_size': 580,
+     'data_types': ['AF', 'seqFish'],
+     'doc_size': 726,
      'donor': {'mapped_metadata': {'gender': 'Masculine gender'},
                'metadata': {'organ_donor_data': [{'data_type': 'Nominal',
                                                   'grouping_concept_preferred_term': 'Gender '
@@ -55,13 +56,17 @@ def transform(doc, batch_id='unspecified'):
                     '1575489509656',
                     '2019-12-04 19:58:29',
                     '5678',
+                    'AF',
+                    'Autofluorescence Microscopy',
                     'Gender finding',
                     'LY01',
                     'Lymph Node',
                     'Masculine gender',
                     'Nominal',
-                    'dataset'],
+                    'dataset',
+                    'seqFish'],
      'mapped_create_timestamp': '2019-12-04 19:58:29',
+     'mapped_data_types': ['Autofluorescence Microscopy', 'seqFish'],
      'origin_sample': {'mapped_organ': 'Lymph Node', 'organ': 'LY01'}}
 
     '''

--- a/src/elasticsearch/addl_index_transformations/portal/__init__.py
+++ b/src/elasticsearch/addl_index_transformations/portal/__init__.py
@@ -27,6 +27,7 @@ def transform(doc, batch_id='unspecified'):
     ...    },
     ...    'create_timestamp': 1575489509656,
     ...    'ancestor_ids': ['1234', '5678'],
+    ...    'data_types': ['AF', 'seqFish'],
     ...    'donor': {
     ...        "metadata": {
     ...             "organ_donor_data": [

--- a/src/elasticsearch/addl_index_transformations/portal/test.sh
+++ b/src/elasticsearch/addl_index_transformations/portal/test.sh
@@ -15,7 +15,7 @@ end flake8
 start doctests
 cd ../../..
 for F in elasticsearch/addl_index_transformations/portal/*.py; do
-  python -m doctest $F
+  python -m doctest -o REPORT_NDIFF $F
 done
 cd -
 end doctests

--- a/src/elasticsearch/addl_index_transformations/portal/translate.py
+++ b/src/elasticsearch/addl_index_transformations/portal/translate.py
@@ -9,6 +9,9 @@ class TranslationException(Exception):
     pass
 
 
+UNEXPECTED = 'Unexpected code'
+
+
 def translate(doc):
     _translate_status(doc)
     _translate_organ(doc)
@@ -68,7 +71,7 @@ def _status_map(k):
     if k_upper == 'QA':
         return 'QA'
     if k_upper not in _status_dict:
-        return 'Unexpected code'
+        return UNEXPECTED
     description = _status_dict[k_upper]
     return description.title()
 
@@ -129,7 +132,7 @@ def _translate_organ(doc):
 
 def _organ_map(k):
     if k not in _organ_dict:
-        return 'Unexpected code'
+        return UNEXPECTED
     return _organ_dict[k]
 
 
@@ -157,7 +160,7 @@ def _translate_specimen_type(doc):
 
 def _specimen_types_map(k):
     if k not in _specimen_types_dict:
-        return 'Unexpected code'
+        return UNEXPECTED
     return _specimen_types_dict[k]
 
 
@@ -185,7 +188,7 @@ def _translate_assay_type(doc):
 
 def _assay_types_map(k):
     if k not in _assay_types_dict:
-        return 'Unexpected code'
+        return UNEXPECTED
     return _assay_types_dict[k]
 
 

--- a/src/elasticsearch/addl_index_transformations/portal/translate.py
+++ b/src/elasticsearch/addl_index_transformations/portal/translate.py
@@ -14,6 +14,7 @@ def translate(doc):
     _translate_organ(doc)
     _translate_donor_metadata(doc)
     _translate_specimen_type(doc)
+    _translate_assay_type(doc)
     _translate_timestamp(doc)
 
 
@@ -163,6 +164,34 @@ def _specimen_types_map(k):
 _specimen_types_dict = {
     k: v['description']
     for k, v in _enums['tissue_sample_types'].items()
+}
+
+
+# Assay type:
+
+def _translate_assay_type(doc):
+    '''
+    >>> doc = {'assay_type': 'AF'}
+    >>> _translate_assay_type(doc); doc
+    {'assay_type': 'AF', 'mapped_assay_type': 'Autofluorescence Microscopy'}
+
+    >>> doc = {'assay_type': 'xyz'}
+    >>> _translate_assay_type(doc); doc
+    {'assay_type': 'xyz', 'mapped_assay_type': 'Unexpected code'}
+
+    '''
+    _map(doc, 'assay_type', _assay_types_map)
+
+
+def _assay_types_map(k):
+    if k not in _assay_types_dict:
+        return 'Unexpected code'
+    return _assay_types_dict[k]
+
+
+_assay_types_dict = {
+    k: v['description']
+    for k, v in _enums['assay_types'].items()
 }
 
 

--- a/src/elasticsearch/addl_index_transformations/portal/translate.py
+++ b/src/elasticsearch/addl_index_transformations/portal/translate.py
@@ -17,7 +17,7 @@ def translate(doc):
     _translate_organ(doc)
     _translate_donor_metadata(doc)
     _translate_specimen_type(doc)
-    _translate_assay_type(doc)
+    _translate_data_type(doc)
     _translate_timestamp(doc)
 
 
@@ -172,29 +172,31 @@ _specimen_types_dict = {
 
 # Assay type:
 
-def _translate_assay_type(doc):
+def _translate_data_type(doc):
     '''
-    >>> doc = {'assay_type': 'AF'}
-    >>> _translate_assay_type(doc); doc
-    {'assay_type': 'AF', 'mapped_assay_type': 'Autofluorescence Microscopy'}
+    >>> doc = {'data_types': ['AF']}
+    >>> _translate_data_type(doc); doc
+    {'data_types': ['AF'], 'mapped_data_types': ['Autofluorescence Microscopy']}
 
-    >>> doc = {'assay_type': 'xyz'}
-    >>> _translate_assay_type(doc); doc
-    {'assay_type': 'xyz', 'mapped_assay_type': 'Unexpected code'}
+    >>> doc = {'data_types': ['xyz']}
+    >>> _translate_data_type(doc); doc
+    {'data_types': ['xyz'], 'mapped_data_types': ['Unexpected code']}
 
     '''
-    _map(doc, 'assay_type', _assay_types_map)
+    _map(doc, 'data_types', _data_types_map)
 
 
-def _assay_types_map(k):
-    if k not in _assay_types_dict:
-        return UNEXPECTED
-    return _assay_types_dict[k]
+def _data_types_map(ks):
+    return [
+        _data_types_dict[k] if k in _data_types_dict else UNEXPECTED
+        for k in ks
+    ]
 
 
-_assay_types_dict = {
+_data_types_dict = {
     k: v['description']
     for k, v in _enums['assay_types'].items()
+    # NOTE: Field name ("data_types") and enum name ("assay_types") do not match!
 }
 
 


### PR DESCRIPTION
The data (ie, assay) type enums were missed on the first pass. There were a lot of strange values earlier, but in the current data, I think the values we see will conform to the search-schema enum