### PR TITLE
Mccalluc/make sure sub objects get mapped

### DIFF
--- a/src/elasticsearch/addl_index_transformations/portal/__init__.py
+++ b/src/elasticsearch/addl_index_transformations/portal/__init__.py
@@ -16,6 +16,9 @@ from elasticsearch.addl_index_transformations.portal.translate import (
 from elasticsearch.addl_index_transformations.portal.add_everything import (
     add_everything
 )
+from elasticsearch.addl_index_transformations.portal.add_counts import (
+    add_counts
+)
 
 
 def transform(doc, batch_id='unspecified'):
@@ -28,7 +31,11 @@ def transform(doc, batch_id='unspecified'):
     ...    },
     ...    'create_timestamp': 1575489509656,
     ...    'ancestor_ids': ['1234', '5678'],
+    ...    'ancestors': [{
+    ...        'specimen_type': 'fresh_frozen_tissue_section'
+    ...    }],
     ...    'data_types': ['AF', 'seqFish'],
+    ...    'descendants': [{'entity_type': 'Sample or Dataset'}],
     ...    'donor': {
     ...        "metadata": {
     ...             "organ_donor_data": [
@@ -45,8 +52,11 @@ def transform(doc, batch_id='unspecified'):
     >>> del transformed['mapper_metadata']['datetime']
     >>> pprint(transformed)
     {'ancestor_ids': ['1234', '5678'],
+     'ancestors': [{'mapped_specimen_type': 'Fresh Frozen Tissue Section',
+                    'specimen_type': 'fresh_frozen_tissue_section'}],
      'create_timestamp': 1575489509656,
      'data_types': ['AF', 'seqFish'],
+     'descendants': [{'entity_type': 'Sample or Dataset'}],
      'donor': {'mapped_metadata': {'gender': 'Masculine gender'},
                'metadata': {'organ_donor_data': [{'data_type': 'Nominal',
                                                   'grouping_concept_preferred_term': 'Gender '
@@ -60,16 +70,19 @@ def transform(doc, batch_id='unspecified'):
                     '5678',
                     'AF',
                     'Autofluorescence Microscopy',
+                    'Fresh Frozen Tissue Section',
                     'Gender finding',
                     'LY01',
                     'Lymph Node',
                     'Masculine gender',
                     'Nominal',
                     'dataset',
+                    'fresh_frozen_tissue_section',
                     'seqFish'],
      'mapped_create_timestamp': '2019-12-04 19:58:29',
      'mapped_data_types': ['Autofluorescence Microscopy', 'seqFish'],
-     'mapper_metadata': {'size': 726, 'version': '0.0.1'},
+     'mapper_metadata': {'size': 908, 'version': '0.0.1'},
+     'descendants': [{'entity_type': 'Sample or Dataset'}],
      'origin_sample': {'mapped_organ': 'Lymph Node', 'organ': 'LY01'}}
 
     '''
@@ -84,6 +97,7 @@ def transform(doc, batch_id='unspecified'):
     except TranslationException as e:
         logging.error(f'Error: {id_for_log}: {e}')
         return None
+    add_counts(doc_copy)
     add_everything(doc_copy)
     doc_copy['mapper_metadata'] = {
         'version': '0.0.1',

--- a/src/elasticsearch/addl_index_transformations/portal/__init__.py
+++ b/src/elasticsearch/addl_index_transformations/portal/__init__.py
@@ -51,11 +51,13 @@ def transform(doc, batch_id='unspecified'):
     ... })
     >>> del transformed['mapper_metadata']['datetime']
     >>> pprint(transformed)
-    {'ancestor_ids': ['1234', '5678'],
+    {'ancestor_counts': {'entity_type': {}},
+     'ancestor_ids': ['1234', '5678'],
      'ancestors': [{'mapped_specimen_type': 'Fresh Frozen Tissue Section',
                     'specimen_type': 'fresh_frozen_tissue_section'}],
      'create_timestamp': 1575489509656,
      'data_types': ['AF', 'seqFish'],
+     'descendant_counts': {'entity_type': {'Sample or Dataset': 1}},
      'descendants': [{'entity_type': 'Sample or Dataset'}],
      'donor': {'mapped_metadata': {'gender': 'Masculine gender'},
                'metadata': {'organ_donor_data': [{'data_type': 'Nominal',
@@ -64,7 +66,8 @@ def transform(doc, batch_id='unspecified'):
                                                   'preferred_term': 'Masculine '
                                                                     'gender'}]}},
      'entity_type': 'dataset',
-     'everything': ['1234',
+     'everything': ['1',
+                    '1234',
                     '1575489509656',
                     '2019-12-04 19:58:29',
                     '5678',
@@ -76,13 +79,13 @@ def transform(doc, batch_id='unspecified'):
                     'Lymph Node',
                     'Masculine gender',
                     'Nominal',
+                    'Sample or Dataset',
                     'dataset',
                     'fresh_frozen_tissue_section',
                     'seqFish'],
      'mapped_create_timestamp': '2019-12-04 19:58:29',
      'mapped_data_types': ['Autofluorescence Microscopy', 'seqFish'],
-     'mapper_metadata': {'size': 908, 'version': '0.0.1'},
-     'descendants': [{'entity_type': 'Sample or Dataset'}],
+     'mapper_metadata': {'size': 1093, 'version': '0.0.2'},
      'origin_sample': {'mapped_organ': 'Lymph Node', 'organ': 'LY01'}}
 
     '''
@@ -100,7 +103,7 @@ def transform(doc, batch_id='unspecified'):
     add_counts(doc_copy)
     add_everything(doc_copy)
     doc_copy['mapper_metadata'] = {
-        'version': '0.0.1',
+        'version': '0.0.2',
         'datetime': str(datetime.datetime.now()),
         'size': len(dumps(doc_copy))
     }

--- a/src/elasticsearch/addl_index_transformations/portal/add_counts.py
+++ b/src/elasticsearch/addl_index_transformations/portal/add_counts.py
@@ -24,8 +24,12 @@ def add_counts(doc):
 
     '''
     doc['ancestor_counts'] = {
-        'entity_type': dict(Counter([entity['entity_type'] for entity in doc['ancestors'] if 'entity_type' in entity]))
+        'entity_type': _count_field(doc['ancestors'], 'entity_type')
     }
     doc['descendant_counts'] = {
-        'entity_type': dict(Counter([entity['entity_type'] for entity in doc['descendants'] if 'entity_type' in entity]))
+        'entity_type': _count_field(doc['descendants'], 'entity_type')
     }
+
+
+def _count_field(doc_list, field):
+    return dict(Counter([entity[field] for entity in doc_list if field in entity]))

--- a/src/elasticsearch/addl_index_transformations/portal/add_counts.py
+++ b/src/elasticsearch/addl_index_transformations/portal/add_counts.py
@@ -24,8 +24,8 @@ def add_counts(doc):
 
     '''
     doc['ancestor_counts'] = {
-        'entity_type': dict(Counter([entity['entity_type'] for entity in doc['ancestors']]))
+        'entity_type': dict(Counter([entity['entity_type'] for entity in doc['ancestors'] if 'entity_type' in entity]))
     }
     doc['descendant_counts'] = {
-        'entity_type': dict(Counter([entity['entity_type'] for entity in doc['descendants']]))
+        'entity_type': dict(Counter([entity['entity_type'] for entity in doc['descendants'] if 'entity_type' in entity]))
     }

--- a/src/elasticsearch/addl_index_transformations/portal/add_counts.py
+++ b/src/elasticsearch/addl_index_transformations/portal/add_counts.py
@@ -1,0 +1,31 @@
+from collections import Counter
+
+
+def add_counts(doc):
+    '''
+    >>> from pprint import pprint
+    >>> doc = {
+    ...    'ancestors': [
+    ...        {'entity_type': 'Donor'},
+    ...        {'entity_type': 'Sample'},
+    ...        {'entity_type': 'Sample'},
+    ...    ],
+    ...    'descendants': [
+    ...        {'entity_type': 'Sample'},
+    ...        {'entity_type': 'Sample'},
+    ...        {'entity_type': 'Dataset'},
+    ...    ]
+    ... }
+    >>> add_counts(doc)
+    >>> pprint(doc['ancestor_counts'])
+    {'entity_type': {'Donor': 1, 'Sample': 2}}
+    >>> pprint(doc['descendant_counts'])
+    {'entity_type': {'Dataset': 1, 'Sample': 2}}
+
+    '''
+    doc['ancestor_counts'] = {
+        'entity_type': dict(Counter([entity['entity_type'] for entity in doc['ancestors']]))
+    }
+    doc['descendant_counts'] = {
+        'entity_type': dict(Counter([entity['entity_type'] for entity in doc['descendants']]))
+    }

--- a/src/elasticsearch/addl_index_transformations/portal/translate.py
+++ b/src/elasticsearch/addl_index_transformations/portal/translate.py
@@ -43,6 +43,9 @@ def _map(doc, key, map):
     if 'source_sample' in doc:
         for sample in doc['source_sample']:
             _map(sample, key, map)
+    if 'ancestors' in doc:
+        for ancestor in doc['ancestors']:
+            _map(ancestor, key, map)
 
 
 # Status:


### PR DESCRIPTION
@tsliaw : Do the `descendant_counts` and `ancestor_counts` look like they'll be sufficient for your needs in the UI? Would it be good to add any other summary stats while we're here? (see https://github.com/hubmapconsortium/portal-ui/issues/672) (ES can [sort of do this natively](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-script-query.html)... but it may be slow, and require features that aren't turned on by default.)
@john-conroy : Does the mapping inside `ancestors` seem good? To confirm, the fields you want are available on the ancestors, they just haven't been mapped? (see https://github.com/hubmapconsortium/portal-ui/issues/662)

@etlds : I'll add you as a reviewer when I've gotten confirmation from my side that this does what we need...
