### PR TITLE
Shirey/remove mult protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The search-api base URL for each deployment environment:
 
 - DEV: `https://search-api.dev.hubmapconsortium.org`
 - TEST: `https://search-api.test.hubmapconsortium.org`
+- STAGE: `https://search-api.stage.hubmapconsortium.org`
 - PROD: `https://search.api.hubmapconsortium.org`
 
 ## Request endpoints

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
   search-api:
     build: ./search-api
     # Build the image with name and tag
-    image: search-api:1.3
+    image: search-api:1.4
     hostname: search-api
     container_name: search-api
     volumes:

--- a/src/elasticsearch/neo4j-to-es-attributes.json
+++ b/src/elasticsearch/neo4j-to-es-attributes.json
@@ -86,10 +86,6 @@
         "es_name": "protocol_url",
         "is_json_stored_as_text": false
       },
-      "protocols": {
-        "es_name": "portal_uploaded_protocol_files",
-        "is_json_stored_as_text": true
-      },
       "provenance_group_name": {
         "es_name": "group_name",
         "is_json_stored_as_text": false


### PR DESCRIPTION
Removed the protocols (neo4j side)/portal_uploaded_protocol_files (ES side) attribute from the index because we no longer accept protocol files or allow multiple protocol.io DOIs (only single one).