### PR TITLE
add data_access_level attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The search-api base URL for each deployment environment:
 
 - DEV: `https://search-api.dev.hubmapconsortium.org`
 - TEST: `https://search-api.test.hubmapconsortium.org`
+- STAGE: `https://search-api.stage.hubmapconsortium.org`
 - PROD: `https://search.api.hubmapconsortium.org`
 
 ## Request endpoints

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
   search-api:
     build: ./search-api
     # Build the image with name and tag
-    image: search-api:1.3
+    image: search-api:1.4
     hostname: search-api
     container_name: search-api
     volumes:

--- a/src/elasticsearch/neo4j-to-es-attributes.json
+++ b/src/elasticsearch/neo4j-to-es-attributes.json
@@ -34,6 +34,10 @@
         "es_name": "lab_tissue_sample_id",
         "is_json_stored_as_text": false
       },
+      "data_access_level": {
+        "es_name": "data_access_level",
+        "is_json_stored_as_text": false
+      },	
       "data_types": {
         "es_name": "data_types",
         "is_json_stored_as_text": true


### PR DESCRIPTION
Add the Metadata.data_access_level attribute (Neo4j) to the default ES index (entities).