### PR TITLE
Add "set -o errexit"

### DIFF
--- a/docker/search-api-docker.sh
+++ b/docker/search-api-docker.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -o errexit
 
 # Print a new line and the banner
 echo

--- a/docker/search-api/entrypoint.sh
+++ b/docker/search-api/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -o errexit
 
 # Pass the HOST_UID and HOST_UID from environment variables specified in the child image docker-compose
 HOST_GID=${HOST_GID}

--- a/generate-build-version.sh
+++ b/generate-build-version.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -o errexit
 
 # Print a new line and the banner
 echo


### PR DESCRIPTION
Bash's default is not to exit on errors: This makes sense when it's used interactively, but it can make scripts hard to debug. Adding `set -o errexit` will make it exit on any non-zero status, which is probably what you want in a script. (Though there are [differences of opinion](http://mywiki.wooledge.org/BashFAQ/105).)

(Also good to be aware of other options, like `pipefail`.)