### PR TITLE
Reorder, add linebreaks between sections

### DIFF
--- a/src/search-schema/data/definitions/enums/assay_types.yaml
+++ b/src/search-schema/data/definitions/enums/assay_types.yaml
@@ -1,13 +1,25 @@
 AF:
     description: Autofluorescence Microscopy
+
 ATACseq-bulk:
     description: Bulk ATAC-seq
+bulk_atacseq:
+    description: Bulk ATAC-seq [BWA + MACS2]
+
+bulk-RNA:
+    description: Bulk RNA-seq
+salmon_rnaseq_bulk:
+    description: Bulk RNA-seq [Salmon]
+
 CODEX:
     description: CODEX
+codex_cytokit:
+    description: CODEX [Cytokit + SPRM]
+
+image_pyramid:
+    description: Image Pyramid
 IMC:
     description: Imaging Mass Cytometry
-LC-MS-untargeted:
-    description: Untargeted LC-MS
 Lightsheet:
     description: Lightsheet Microscopy
 MALDI-IMS-neg:
@@ -24,47 +36,47 @@ TMT-LC-MS:
     description: TMT LC-MS
 Targeted-Shotgun-LC-MS:
     description: Targeted Shotgun / Flow-injection LC-MS
+LC-MS-untargeted:
+    description: Untargeted LC-MS
 WGS:
     description: Whole Genome Sequencing
-bulk-RNA:
-    description: Bulk RNA-seq
-codex_cytokit:
-    description: CODEX [Cytokit + SPRM]
-image_pyramid:
-    description: Image Pyramid
-salmon_rnaseq_10x:
-    description: scRNA-seq (10x Genomics) [Salmon]
-salmon_rnaseq_bulk:
-    description: Bulk RNA-seq [Salmon]
-salmon_rnaseq_sciseq:
-    description: sciRNA-seq [Salmon]
-salmon_rnaseq_snareseq:
-    description: scRNA-seq (SNARE-seq) [Salmon]
-sc_atac_seq_snare:
-    description: scATAC-seq (SNARE-seq) [SnapATAC]
-sc_rna_seq_snare_lab:
-    description: scRNA-seq (SNARE-seq) [Lab Processed]
+
 sc_atac_seq_snare_lab:
     description: scATAC-seq (SNARE-seq) [Lab Processed]
+sc_atac_seq_snare:
+    description: scATAC-seq (SNARE-seq) [SnapATAC]
+
 scRNA-Seq-10x:
     description: scRNA-seq (10x Genomics)
+salmon_rnaseq_10x:
+    description: scRNA-seq (10x Genomics) [Salmon]
+
+sc_rna_seq_snare_lab:
+    description: scRNA-seq (SNARE-seq) [Lab Processed]
+salmon_rnaseq_snareseq:
+    description: scRNA-seq (SNARE-seq) [Salmon]
+
 sciATACseq:
     description: sciATAC-seq
 sc_atac_seq_sci:
     description: sciATAC-seq [SnapATAC]
+
 sciRNAseq:
     description: sciRNA-seq
+salmon_rnaseq_sciseq:
+    description: sciRNA-seq [Salmon]
+
 seqFish:
     description: seqFISH
 seqFish_lab_processed:
     description: seqFISH [Lab Processed]
+
 snATACseq:
     description: snATAC-seq
-snRNAseq:
-    description: snRNA-seq
-bulk_atacseq:
-    description: Bulk ATAC-seq [BWA + MACS2]
 sn_atac_seq:
     description: snATAC-seq [SnapATAC]
+
+snRNAseq:
+    description: snRNA-seq
 salmon_sn_rnaseq_10x:
     description: snRNA-seq [Salmon]


### PR DESCRIPTION
The list of assays was hard to skim because items had been added on an ad-hoc basis. This just sorts the list by the `description` strings, and add linebreaks between blocks.

@cebriggs7135 : Are you ok with `scATAC-seq (SNARE-seq) [Lab Processed]`, `scRNA-seq (SNARE-seq) [Lab Processed]`, and `seqFISH [Lab Processed]` being used in metadata TSVs? These would be the only terms in metadata TSVs which include processing info in square brackets.

For reference:
```python
from pathlib import Path
from yaml import safe_load, dump

p = Path('src/search-schema/data/definitions/enums/assay_types.yaml')
items = safe_load(p.read_text()).items()
sorted_items = sorted(items, key=lambda item: item[1]['description'])
for i in sorted_items:
  print(f'{i[0]}:')
  print(f'    description: {i[1]["description"]}')
```