### PR TITLE
Mccalluc/validate

### DIFF
--- a/src/elasticsearch/addl_index_transformations/portal/__init__.py
+++ b/src/elasticsearch/addl_index_transformations/portal/__init__.py
@@ -181,18 +181,12 @@ def _simple_clean(doc):
 #             del doc[unused_key]
 
 
-_schemas = {
-    entity_type:
-        load_yaml((
-            _data_dir / 'generated' / f'{entity_type}.schema.yaml'
-        ).read_text())
-    for entity_type in ['dataset', 'donor', 'sample']
-}
-
-
 def _get_schema(doc):
     entity_type = doc['entity_type'].lower()
-    return _schemas[entity_type]
+    schema = load_yaml((
+        _data_dir / 'generated' / f'{entity_type}.schema.yaml'
+    ).read_text())
+    return schema
 
 
 def _add_validation_errors(doc):

--- a/src/elasticsearch/addl_index_transformations/portal/__init__.py
+++ b/src/elasticsearch/addl_index_transformations/portal/__init__.py
@@ -190,7 +190,28 @@ def _get_schema(doc):
 
 
 def _add_validation_errors(doc):
-    validator = jsonschema.Draft7Validator(_get_schema(doc))
+    '''
+    >>> from pprint import pprint
+
+    >>> doc = {'entity_type': 'JUST WRONG'}
+    >>> _add_validation_errors(doc)
+    Traceback (most recent call last):
+    ...
+    FileNotFoundError: [Errno 2] No such file or directory: 'search-schema/data/generated/just wrong.schema.yaml'
+
+    >>> doc = {'entity_type': 'dataset'}
+    >>> _add_validation_errors(doc)
+    >>> pprint(doc['mapper_metadata']['validation_errors'][0])
+    {'absolute_path': '/entity_type',
+     'absolute_schema_path': '/properties/entity_type/enum',
+     'message': "'dataset' is not one of ['Dataset', 'Donor', 'Sample']"}
+
+    '''
+    schema = _get_schema(doc)
+    if not schema.keys():
+        doc['mapper_metadata'] = {'validation_errors': ["Can't load schema"]}
+        return
+    validator = jsonschema.Draft7Validator(schema)
     errors = [
         {
             'message': e.message,

--- a/src/elasticsearch/addl_index_transformations/portal/add_everything.py
+++ b/src/elasticsearch/addl_index_transformations/portal/add_everything.py
@@ -44,7 +44,7 @@ def _get_nested_values(input):
     ['deep', 'deep!', 'deep', 'shallow', '123']
 
     '''
-    dont_recurse_on = single_valued_fields + multi_valued_fields
+    dont_recurse_on = single_valued_fields + multi_valued_fields + ['mapper_validation_errors']
     if isinstance(input, dict):
         for k, v in input.items():
             if k not in dont_recurse_on:

--- a/src/elasticsearch/addl_index_transformations/portal/add_everything.py
+++ b/src/elasticsearch/addl_index_transformations/portal/add_everything.py
@@ -44,7 +44,7 @@ def _get_nested_values(input):
     ['deep', 'deep!', 'deep', 'shallow', '123']
 
     '''
-    dont_recurse_on = single_valued_fields + multi_valued_fields + ['mapper_validation_errors']
+    dont_recurse_on = single_valued_fields + multi_valued_fields + ['validation_errors']
     if isinstance(input, dict):
         for k, v in input.items():
             if k not in dont_recurse_on:

--- a/src/elasticsearch/addl_index_transformations/portal/test.sh
+++ b/src/elasticsearch/addl_index_transformations/portal/test.sh
@@ -13,7 +13,9 @@ end portal/flake8
 start portal/doctests
 cd ../../..
 for F in elasticsearch/addl_index_transformations/portal/*.py; do
-  python -m doctest -o REPORT_NDIFF $F
+  CMD="python -m doctest -o REPORT_NDIFF $F"
+  echo $CMD
+  eval $CMD
 done
 cd -
 end portal/doctests

--- a/src/search-schema/generate-schemas.sh
+++ b/src/search-schema/generate-schemas.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -o errexit
+
+BASE=$(dirname $0)
+YAML=$BASE/data/generated/combined-definitions.yaml
+$BASE/src/consolidate-yaml.py \
+  --definitions $BASE/data/definitions > $YAML
+$BASE/src/definitions-yaml-to-schema.py \
+  --definitions $YAML \
+  --schemas $BASE/data/generated/

--- a/src/search-schema/test.sh
+++ b/src/search-schema/test.sh
@@ -14,14 +14,7 @@ start search-schema/doctests
 end search-schema/doctests
 
 start search-schema/examples
-  YAML=data/generated/combined-definitions.yaml
-  src/consolidate-yaml.py --definitions data/definitions > $YAML
-
-  CMD="src/definitions-yaml-to-schema.py --definitions $YAML --schemas data/generated/"
-
-  echo "Running '$CMD'"
-  eval $CMD
-
+  ./generate-schemas.sh
   for EXAMPLE in examples/*; do
     TYPE=`basename $EXAMPLE .json`
     src/validate.py --document $EXAMPLE --schema data/generated/$TYPE.schema.yaml


### PR DESCRIPTION
At index time, validate documents, and record any errors in the metadata. The subprocess call is inelegant, but not a performance concern, since it will only be called once, and then the schemas are in place. (Though it might cause a problem if the image doesn't have bash available?)

Another option would be either error out or log a message if there a validation problems... If you'd like it to be stricter, I won't stop you, but my sense is that we'd prefer to clean up problems after the fact, rather than have problems at index-time; Similarly with logging: I think you probably want to minimize log noise.