### PR TITLE
Always regen schema

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -8,9 +8,3 @@ services:
       - HOST_UID=${HOST_UID:-1000}
     init: true
     restart: always
-    volumes:
-      # Mount the VERSION file and BUILD file
-      - "../VERSION:/usr/src/app/src/VERSION"
-      - "../BUILD:/usr/src/app/src/BUILD"
-      # Mount the source code to container
-      - "../src:/usr/src/app/src"

--- a/docker/search-api-docker.sh
+++ b/docker/search-api-docker.sh
@@ -95,9 +95,9 @@ else
             # Copy over the src folder
             cp -r ../src search-api/
 
-            # Only mount the VERSION file and BUILD file for localhost and dev
-            # On test/stage/prod, copy the VERSION file and BUILD file to image
-            if [[ "$1" != "localhost" && "$1" != "dev" ]]; then
+            # Only mount the VERSION file and BUILD file for localhost
+            # On dev/test/stage/prod, copy the VERSION file and BUILD file to image
+            if [ "$1" != "localhost" ]; then
                 # Delete old VERSION and BUILD files if found
                 if [ -f "search-api/src/VERSION" ]; then
                     rm -rf search-api/src/VERSION

--- a/docker/search-api/Dockerfile
+++ b/docker/search-api/Dockerfile
@@ -18,6 +18,8 @@ COPY . .
 RUN pip install -r src/requirements.txt && \
     pip install src/
 
+RUN src/search-schema/generate-schemas.sh
+
 # The EXPOSE instruction informs Docker that the container listens on the specified network ports at runtime. 
 # EXPOSE does not make the ports of the container accessible to the host.
 EXPOSE 5000

--- a/docker/search-api/Dockerfile
+++ b/docker/search-api/Dockerfile
@@ -18,6 +18,8 @@ COPY . .
 RUN pip install -r src/requirements.txt && \
     pip install src/
 
+# Generate the combined schema definition yaml file
+RUN chmod +x src/search-schema/generate-schemas.sh
 RUN src/search-schema/generate-schemas.sh
 
 # The EXPOSE instruction informs Docker that the container listens on the specified network ports at runtime. 

--- a/docker/search-api/entrypoint.sh
+++ b/docker/search-api/entrypoint.sh
@@ -17,9 +17,6 @@ if [ $? -ne 0 ]; then
     useradd -r -u $HOST_UID -g $HOST_GID -m hubmap
 fi
 
-# Make the source code directory writable
-chown -R hubmap:hubmap /usr/src/app/src
-
 # Lastly we use gosu to execute our process "$@" as that user
 # Remember CMD from a Dockerfile of child image gets passed to the entrypoint.sh as command line arguments
 # "$@" is a shell variable that means "all the arguments"

--- a/docker/search-api/entrypoint.sh
+++ b/docker/search-api/entrypoint.sh
@@ -17,6 +17,9 @@ if [ $? -ne 0 ]; then
     useradd -r -u $HOST_UID -g $HOST_GID -m hubmap
 fi
 
+# Make the source code directory writable
+chown -R hubmap:hubmap /usr/src/app/src
+
 # Lastly we use gosu to execute our process "$@" as that user
 # Remember CMD from a Dockerfile of child image gets passed to the entrypoint.sh as command line arguments
 # "$@" is a shell variable that means "all the arguments"

--- a/src/elasticsearch/addl_index_transformations/portal/__init__.py
+++ b/src/elasticsearch/addl_index_transformations/portal/__init__.py
@@ -203,10 +203,11 @@ def _simple_clean(doc):
 def _get_schema(doc):
     entity_type = doc['entity_type'].lower()
     schema_path = _data_dir / 'generated' / f'{entity_type}.schema.yaml'
-    if not schema_path.exists():
-        # TODO: Doing this in python is preferable to subprocess!
-        script_path = _data_dir.parent / 'generate-schemas.sh'
-        subprocess.run([script_path], check=True)
+    # NOTE: The schema could be reused between runs. ie
+    # > if not schema_path.exists():
+    # TODO: Doing this in python is preferable to subprocess!
+    script_path = _data_dir.parent / 'generate-schemas.sh'
+    subprocess.run([script_path], check=True)
     schema = load_yaml((
         _data_dir / 'generated' / f'{entity_type}.schema.yaml'
     ).read_text())

--- a/src/elasticsearch/addl_index_transformations/portal/__init__.py
+++ b/src/elasticsearch/addl_index_transformations/portal/__init__.py
@@ -208,9 +208,7 @@ def _get_schema(doc):
     # TODO: Doing this in python is preferable to subprocess!
     script_path = _data_dir.parent / 'generate-schemas.sh'
     subprocess.run([script_path], check=True)
-    schema = load_yaml((
-        _data_dir / 'generated' / f'{entity_type}.schema.yaml'
-    ).read_text())
+    schema = load_yaml(schema_path.read_text())
     return schema
 
 

--- a/src/elasticsearch/addl_index_transformations/portal/__init__.py
+++ b/src/elasticsearch/addl_index_transformations/portal/__init__.py
@@ -257,8 +257,18 @@ def _add_validation_errors(doc):
     errors = [
         {
             'message': e.message,
-            'absolute_schema_path': '/' + '/'.join(e.absolute_schema_path),
-            'absolute_path': '/' + '/'.join(e.absolute_path)
+            'absolute_schema_path': _as_path_string(e.absolute_schema_path),
+            'absolute_path': _as_path_string(e.absolute_path)
         } for e in validator.iter_errors(doc)
     ]
     doc['mapper_metadata'] = {'validation_errors': errors}
+
+
+def _as_path_string(mixed):
+    '''
+    >>> _as_path_string(['a', 2, 'z'])
+    '/a/2/z'
+
+    '''
+    sep = '/'
+    return sep + sep.join(str(s) for s in mixed)

--- a/src/elasticsearch/addl_index_transformations/portal/__init__.py
+++ b/src/elasticsearch/addl_index_transformations/portal/__init__.py
@@ -203,11 +203,10 @@ def _simple_clean(doc):
 def _get_schema(doc):
     entity_type = doc['entity_type'].lower()
     schema_path = _data_dir / 'generated' / f'{entity_type}.schema.yaml'
-    # NOTE: The schema could be reused between runs. ie
-    # > if not schema_path.exists():
-    # TODO: Doing this in python is preferable to subprocess!
-    script_path = _data_dir.parent / 'generate-schemas.sh'
-    subprocess.run([script_path], check=True)
+    if not schema_path.exists():
+        # TODO: Doing this in python is preferable to subprocess!
+        script_path = _data_dir.parent / 'generate-schemas.sh'
+        subprocess.run([script_path], check=True)
     schema = load_yaml(schema_path.read_text())
     return schema
 


### PR DESCRIPTION
I believe that running the schema generation as part of the docker build, or running it once and then caching the result is slightly preferable to this, but it's really an implementation detail which is in your court.