### PR TITLE
Welling/unified assay names 202011

### DIFF
--- a/examples/libs/assay_type_out.txt
+++ b/examples/libs/assay_type_out.txt
@@ -1,0 +1,15 @@
+codex (this should fail) -> exception No such assay_type codex, even as alternate name
+CODEX produced CODEX CODEX
+{'name': 'CODEX', 'primary': True, 'description': 'CODEX'}
+codex_cytokit produced codex_cytokit CODEX [Cytokit + SPRM]
+{'name': 'codex_cytokit', 'primary': False, 'description': 'CODEX [Cytokit + SPRM]'}
+salmon_rnaseq_bulk produced salmon_rnaseq_bulk Bulk RNA-seq [Salmon]
+{'name': 'salmon_rnaseq_bulk', 'primary': False, 'description': 'Bulk RNA-seq [Salmon]'}
+['PAS', 'Image Pyramid'] (this is a complex alt name) -> exception No such assay_type ['PAS', 'Image Pyramid'], even as alternate name
+['IMC', 'foo'] (this is an invalid complex alt name) -> exception No such assay_type ['IMC', 'foo'], even as alternate name
+all names:
+['AF', 'ATACseq-bulk', 'bulk_atacseq', 'CODEX', 'codex_cytokit', 'image_pyramid', 'IMC', 'lc-ms_label-free', 'lc-ms_labeled', 'lc-ms-ms_label-free', 'lc-ms-ms_labeled', 'LC-MS-untargeted', 'Lightsheet', 'MALDI-IMS-neg', 'MALDI-IMS-pos', 'MxIF', 'PAS', 'bulk-RNA', 'salmon_rnaseq_bulk', 'SNAREseq', 'sc_atac_seq_snare_lab', 'sc_atac_seq_snare', 'scRNA-Seq-10x', 'salmon_rnaseq_10x', 'sc_rna_seq_snare_lab', 'salmon_rnaseq_snareseq', 'sciATACseq', 'sc_atac_seq_sci', 'sciRNAseq', 'salmon_rnaseq_sciseq', 'seqFish', 'seqFish_lab_processed', 'snATACseq', 'sn_atac_seq', 'snRNAseq', 'salmon_sn_rnaseq_10x', 'Targeted-Shotgun-LC-MS', 'TMT-LC-MS', 'WGS']
+primary names:
+['AF', 'ATACseq-bulk', 'CODEX', 'IMC', 'lc-ms_label-free', 'lc-ms_labeled', 'lc-ms-ms_label-free', 'lc-ms-ms_labeled', 'LC-MS-untargeted', 'Lightsheet', 'MALDI-IMS-neg', 'MALDI-IMS-pos', 'MxIF', 'PAS', 'bulk-RNA', 'SNAREseq', 'sc_atac_seq_snare_lab', 'scRNA-Seq-10x', 'sc_rna_seq_snare_lab', 'sciATACseq', 'sc_atac_seq_sci', 'sciRNAseq', 'seqFish', 'seqFish_lab_processed', 'snATACseq', 'snRNAseq', 'Targeted-Shotgun-LC-MS', 'TMT-LC-MS', 'WGS']
+non-primary names:
+['bulk_atacseq', 'codex_cytokit', 'image_pyramid', 'salmon_rnaseq_bulk', 'sc_atac_seq_snare', 'salmon_rnaseq_10x', 'salmon_rnaseq_snareseq', 'salmon_rnaseq_sciseq', 'sn_atac_seq', 'salmon_sn_rnaseq_10x']

--- a/search-api-spec.yaml
+++ b/search-api-spec.yaml
@@ -10,6 +10,8 @@ info:
 tags:
   - name: 'Search API, Elasticsearch'
     description: Operations pertaining to datasets indexed in Elasticsearch
+  - name: assaytype
+    description: Operations pertaining to assay types
 
 externalDocs:
   description: Elasticsearch API Documentation
@@ -20,6 +22,113 @@ security:
   - JWTBearerAuth: [] 
   
 paths:
+
+  '/assaytype':
+    get:
+      tags:
+        - assaytype
+      summary: Get a list of HuBMAP assay type names or descriptive dicts
+      operationId: listAssayType
+      parameters:
+        - name: primary
+          in: query
+          description: >
+             If present and true, restrict list to primary datasets.
+             A primary dataset is one for which no parent is a dataset.
+             If present and false, restrict list to datasets which are not primary.
+          required: false
+          schema:
+             type: boolean
+        - name: simple
+          in: query
+          description: >
+             If present and true, list only assay type names.  Otherwise return a list
+             of descriptive dicts.
+          required: false
+          schema:
+             type: boolean
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                properties:
+                  result:
+                    type: array
+                    items:
+                       oneOf:
+                          - type: string
+                          - $ref: '#/components/schemas/AssayTypeReturnDict'
+        "400":
+          description: The user sent a bad parameter (e.g. a nonexistent group name) or there was a system error
+        "401":
+          description: User's token is not valid
+
+  '/assaytype/{name}':
+    get:
+      tags:
+        - assaytype
+      summary: Get a descriptive dict for a single assay type
+      operationId: getAssayType
+      parameters:
+        - name: primary
+          in: query
+          description: >
+             If present and true, restrict list to primary datasets.
+             A primary dataset is one for which no parent is a dataset.
+             If present and false, restrict list to datasets which are not primary.
+          required: false
+          schema:
+             type: boolean
+        - name: simple
+          in: query
+          description: >
+             If present and true, list only assay type names.  Otherwise return a list
+             of descriptive dicts.
+          required: false
+          schema:
+             type: boolean
+        - name: name
+          in: path
+          description: An assay type name or single-word alternate name
+          required: true
+          schema:
+             type: string
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssayTypeReturnDict'
+        "400":
+          description: The user sent a bad parameter (e.g. a nonexistent group name) or there was a system error
+        "401":
+          description: User's token is not valid
+
+  '/assayname':
+    post:
+      tags:
+        - assaytype
+      summary: Get a descriptive dict for a single assay type
+      operationId: postAssayName
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssayTypeQueryDict'
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssayTypeReturnDict'
+        "400":
+          description: The user sent a bad parameter (e.g. a nonexistent group name) or there was a system error
+        "401":
+          description: User's token is not valid
 
   '/indices':
     get:
@@ -178,3 +287,17 @@ components:
   schemas:
     requestJsonBody:
       type: object
+    AssayTypeQueryDict:
+      type: object
+      properties:
+        name:
+          type: string
+    AssayTypeReturnDict:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        primary:
+          type: boolean

--- a/src/libs/assay_type.py
+++ b/src/libs/assay_type.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Union, List, TypeVar, Iterable
+from typing import Union, List, TypeVar, Iterable, Dict, Any
 import logging
 from yaml import safe_load
 from yaml.error import YAMLError
@@ -12,6 +12,8 @@ from hubmap_commons.schema_tools import (assert_json_matches_schema,
 logging.basicConfig(level=logging.DEBUG)
 
 LOGGER = logging.getLogger(__name__)
+
+JSONType = Union[str, int, float, bool, None, Dict[str, Any], List[Any]]
 
 BoolOrNone = Union[bool, None]
 
@@ -66,7 +68,6 @@ class AssayType(object):
         """
         self._maybe_load_defs()
         safe_name = name if isinstance(name, str) else tuple(name)
-        print(f'testing {name} {safe_name}')
         if safe_name in self.definitions:
             self.name = safe_name
         elif safe_name in self.alt_name_map:
@@ -76,6 +77,13 @@ class AssayType(object):
                                ' even as alternate name')
         self.description = self.definitions[self.name]['description']
         self.primary = self.definitions[self.name]['primary']
+
+    def to_json(self) -> JSONType:
+        """
+        Returns a JSON-compatible representation of the assay type
+        """
+        return {'name': self.name, 'primary': self.primary,
+                'description': self.description}
 
     @classmethod
     def iter_names(cls, primary: BoolOrNone = None) -> Iterable[str]:
@@ -116,6 +124,7 @@ def main() -> None:
         try:
             assay = AssayType(name)
             print(f'{name} produced {assay.name} {assay.description}')
+            print(f'{assay.to_json()}')
         except Exception as e:
             print(f'{name} ({note}) -> exception {e}')
 

--- a/src/libs/assay_type.py
+++ b/src/libs/assay_type.py
@@ -1,12 +1,12 @@
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Pattern, Tuple, TypeVar, Union
+from typing import Union, List, TypeVar, Iterable
 import logging
 from yaml import safe_load
 from yaml.error import YAMLError
-from pprint import pprint
 
 # HuBMAP commons
-from hubmap_commons.schema_tools import assert_json_matches_schema, set_schema_base_path
+from hubmap_commons.schema_tools import (assert_json_matches_schema,
+                                         set_schema_base_path)
 
 # Set logging level (default is warning)
 logging.basicConfig(level=logging.DEBUG)
@@ -15,12 +15,7 @@ LOGGER = logging.getLogger(__name__)
 
 BoolOrNone = Union[bool, None]
 
-JSONType = Union[str, int, float, bool, None, Dict[str, Any], List[Any]]
-
-# Some functions accept a `str` or `List[str]` and return that same type
 StrOrListStr = TypeVar('StrOrListStr', str, List[str])
-
-PathStrOrList = Union[str, Path, Iterable[Union[str, Path]]]
 
 DEFINITION_PATH = (Path(__file__).resolve().parent.parent
                    / 'search-schema' / 'data'
@@ -29,12 +24,17 @@ DEFINITION_PATH = (Path(__file__).resolve().parent.parent
 SCHEMA_PATH = (Path(__file__).resolve().parent) / 'assay_type_schema.yml'
 SCHEMA_BASE_URI = 'http://schemata.hubmapconsortium.org/'
 
+
 class AssayType(object):
+    """
+    A class intended to represent a single assay type, derived or otherwise.
+    """
     definitions = None  # lazy load
-    alt_name_map = {}
+    alt_name_map = {}   # map from alt assay names to canonical name
 
     @classmethod
     def _maybe_load_defs(cls) -> None:
+        """If the assay type table has not been loaded, do so."""
         if not(cls.definitions):
             try:
                 with open(DEFINITION_PATH) as f:
@@ -43,33 +43,54 @@ class AssayType(object):
                 assert_json_matches_schema(cls.definitions, SCHEMA_PATH)
                 for k, v in cls.definitions.items():
                     for alt_k in v['alt-names']:
-                        safe_alt_k = tuple(alt_k) if isinstance(alt_k, list) else alt_k
+                        safe_alt_k = (tuple(alt_k) if isinstance(alt_k, list)
+                                      else alt_k)
                         cls.alt_name_map[safe_alt_k] = k
             except IOError as e:
-                LOGGER.error(f'io error {e}')
+                LOGGER.error(f'io error {e} reading assay type table')
                 raise
             except YAMLError as e:
-                LOGGER.error(f'yaml error {e}')
+                LOGGER.error(f'yaml error {e} reading assay type table')
                 raise
-            except AssertionError as e:
-                print('SCHEMA CHECK FAILED')
-                LOGGER.error(f'assay type table did not match its schema')
+            except AssertionError:
+                LOGGER.error('assay type table did not match its schema')
                 cls.definitions = None
                 raise
 
-    def __init__(self, name: str):
+    def __init__(self, name: StrOrListStr):
+        """
+        name can be either the canonical name of an assay or an alternate name.
+
+        All names are simple strings, but some alt-names are ordered lists of
+        simple strings, e.g. ['IMC', 'image_pyramid'].
+        """
         self._maybe_load_defs()
-        if name in self.definitions:
-            self.name = name
-        elif name in self.alt_name_map:
-            self.name = self.alt_name_map[name]
+        safe_name = name if isinstance(name, str) else tuple(name)
+        print(f'testing {name} {safe_name}')
+        if safe_name in self.definitions:
+            self.name = safe_name
+        elif safe_name in self.alt_name_map:
+            self.name = self.alt_name_map[safe_name]
         else:
-            raise RuntimeError(f'No such assay_type {name}, even as alternate name')
+            raise RuntimeError(f'No such assay_type {name},'
+                               ' even as alternate name')
         self.description = self.definitions[self.name]['description']
         self.primary = self.definitions[self.name]['primary']
-    
+
     @classmethod
-    def iter_names(cls, primary: BoolOrNone = None):
+    def iter_names(cls, primary: BoolOrNone = None) -> Iterable[str]:
+        """
+        Returns an iterator over valid canonical assay type names
+
+            primary: controls the subset of assay names returned:
+                None (defaulted): iterate over all valid canonical names
+                True: iterate only primary assay names, that is, those for
+                    which a dataset of this type has no parent which is also
+                    a dataset.
+             False: iterate only over the names of derived assays, that is,
+                    those for which a dataset of the given type has at least
+                    one parent which is also a dataset.
+        """
         cls._maybe_load_defs()
         if primary is None:
             for key in cls.definitions:
@@ -85,21 +106,26 @@ def main() -> None:
     Some test routines
     """
     for name, note in [('codex', 'this should fail'),
-                        ('CODEX', 'this should work'),
-                        ('codex_cytokit', 'this is not primary'),
-                        ('salmon_rnaseq_bulk', 'this is an alt name')]:
+                       ('CODEX', 'this should work'),
+                       ('codex_cytokit', 'this is not primary'),
+                       ('salmon_rnaseq_bulk', 'this is an alt name'),
+                       (['PAS', 'Image Pyramid'],
+                        'this is a complex alt name'),
+                       (['IMC', 'foo'],
+                        'this is an invalid complex alt name')]:
         try:
             assay = AssayType(name)
             print(f'{name} produced {assay.name} {assay.description}')
         except Exception as e:
             print(f'{name} ({note}) -> exception {e}')
-    
+
     print('all names:')
     print([k for k in AssayType.iter_names()])
     print('primary names:')
     print([k for k in AssayType.iter_names(primary=True)])
     print('non-primary names:')
     print([k for k in AssayType.iter_names(primary=False)])
-    
+
+
 if __name__ == '__main__':
     main()

--- a/src/libs/assay_type.py
+++ b/src/libs/assay_type.py
@@ -1,0 +1,105 @@
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Pattern, Tuple, TypeVar, Union
+import logging
+from yaml import safe_load
+from yaml.error import YAMLError
+from pprint import pprint
+
+# HuBMAP commons
+from hubmap_commons.schema_tools import assert_json_matches_schema, set_schema_base_path
+
+# Set logging level (default is warning)
+logging.basicConfig(level=logging.DEBUG)
+
+LOGGER = logging.getLogger(__name__)
+
+BoolOrNone = Union[bool, None]
+
+JSONType = Union[str, int, float, bool, None, Dict[str, Any], List[Any]]
+
+# Some functions accept a `str` or `List[str]` and return that same type
+StrOrListStr = TypeVar('StrOrListStr', str, List[str])
+
+PathStrOrList = Union[str, Path, Iterable[Union[str, Path]]]
+
+DEFINITION_PATH = (Path(__file__).resolve().parent.parent
+                   / 'search-schema' / 'data'
+                   / 'definitions' / 'enums' / 'assay_types.yaml')
+
+SCHEMA_PATH = (Path(__file__).resolve().parent) / 'assay_type_schema.yml'
+SCHEMA_BASE_URI = 'http://schemata.hubmapconsortium.org/'
+
+class AssayType(object):
+    definitions = None  # lazy load
+    alt_name_map = {}
+
+    @classmethod
+    def _maybe_load_defs(cls) -> None:
+        if not(cls.definitions):
+            try:
+                with open(DEFINITION_PATH) as f:
+                    cls.definitions = safe_load(f)
+                set_schema_base_path(SCHEMA_PATH.parent, SCHEMA_BASE_URI)
+                assert_json_matches_schema(cls.definitions, SCHEMA_PATH)
+                for k, v in cls.definitions.items():
+                    for alt_k in v['alt-names']:
+                        safe_alt_k = tuple(alt_k) if isinstance(alt_k, list) else alt_k
+                        cls.alt_name_map[safe_alt_k] = k
+            except IOError as e:
+                LOGGER.error(f'io error {e}')
+                raise
+            except YAMLError as e:
+                LOGGER.error(f'yaml error {e}')
+                raise
+            except AssertionError as e:
+                print('SCHEMA CHECK FAILED')
+                LOGGER.error(f'assay type table did not match its schema')
+                cls.definitions = None
+                raise
+
+    def __init__(self, name: str):
+        self._maybe_load_defs()
+        if name in self.definitions:
+            self.name = name
+        elif name in self.alt_name_map:
+            self.name = self.alt_name_map[name]
+        else:
+            raise RuntimeError(f'No such assay_type {name}, even as alternate name')
+        self.description = self.definitions[self.name]['description']
+        self.primary = self.definitions[self.name]['primary']
+    
+    @classmethod
+    def iter_names(cls, primary: BoolOrNone = None):
+        cls._maybe_load_defs()
+        if primary is None:
+            for key in cls.definitions:
+                yield key
+        else:
+            for key in [k for k in cls.definitions
+                        if cls.definitions[k]['primary'] == primary]:
+                yield key
+
+
+def main() -> None:
+    """
+    Some test routines
+    """
+    for name, note in [('codex', 'this should fail'),
+                        ('CODEX', 'this should work'),
+                        ('codex_cytokit', 'this is not primary'),
+                        ('salmon_rnaseq_bulk', 'this is an alt name')]:
+        try:
+            assay = AssayType(name)
+            print(f'{name} produced {assay.name} {assay.description}')
+        except Exception as e:
+            print(f'{name} ({note}) -> exception {e}')
+    
+    print('all names:')
+    print([k for k in AssayType.iter_names()])
+    print('primary names:')
+    print([k for k in AssayType.iter_names(primary=True)])
+    print('non-primary names:')
+    print([k for k in AssayType.iter_names(primary=False)])
+    
+if __name__ == '__main__':
+    main()

--- a/src/libs/assay_type_schema.yml
+++ b/src/libs/assay_type_schema.yml
@@ -1,0 +1,36 @@
+'$schema': 'http://json-schema.org/schema#'
+'$id': 'http://schemata.hubmapconsortium.org/assay_type_schema.yml'
+'title': 'assay type schema'
+'description': 'schema for assay type information'
+
+'allOf': [{'$ref': '#/definitions/assay_type_table'}]
+
+'definitions':
+
+   'assay_type_entry':
+     'type': 'object'
+     'properties':
+        'description':
+          'type': 'string'
+          'description': 'a human-readable description of the assay type'
+        'alt-names':
+          'type': 'array'
+          'items':
+            'oneOf': [
+              {'type': 'string',
+               'description': 'an alternate but obsolete name for this assay type'},
+              {'type': 'array',
+               'items': {'type': 'string'},
+               'description': 'an alternate but obsolete name for this assay type'}
+            ]
+        'primary':
+           'type': 'boolean'
+     'required': ['description', 'alt-names', 'primary']
+
+   'assay_type_table':
+      'type': 'object'
+      'propertyNames':
+         'pattern': '^[A-Za-z_\-]*'
+      'additionalProperties':
+        '$ref': '#/definitions/assay_type_entry'
+    

--- a/src/libs/test.sh
+++ b/src/libs/test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -o errexit
+
+. test-utils.sh
+
+cd `dirname $0`
+
+topdir=${PWD}/../..
+reldir=`realpath --relative-to $topdir .`
+
+start libs/assay_type
+CMD="python ./assay_type.py"
+diff ${topdir}/examples/libs/assay_type_out.txt <( eval $CMD ) \
+  || die "Try: python ${reldir}/assay_type.py > examples/libs/assay_type_out.txt"
+end libs/assay_type
+

--- a/src/search-schema/data/definitions/enums/assay_types.yaml
+++ b/src/search-schema/data/definitions/enums/assay_types.yaml
@@ -3,93 +3,244 @@
 
 AF:
     description: Autofluorescence Microscopy
+    alt-names: []
+    primary: true
+
+AF_pyramid:
+    description: Autofluorescence Microscopy [Image Pyramid]
+    alt-names: [["AF", "Image Pyramid"], ["Image Pyramid", "AF"]]
+    primary: false
 
 ATACseq-bulk:
     description: Bulk ATAC-seq
-bulk_atacseq:
-    description: Bulk ATAC-seq [BWA + MACS2]
+    alt-names: []
+    primary: true
 
-bulk-RNA:
-    description: Bulk RNA-seq
-salmon_rnaseq_bulk:
-    description: Bulk RNA-seq [Salmon]
+ATACseq-bulk_BWA_MACS2:
+    description: Bulk ATAC-seq [BWA + MACS2]
+    alt-names: [bulk-atacseq]
+    primary: false
+
+cellDIVE:
+    description: ????
+    alt-names: []
+    primary: true
 
 CODEX:
     description: CODEX
+    alt-names: []
+    primary: true
+
 codex_cytokit:
     description: CODEX [Cytokit + SPRM]
+    alt-names: []
+    primary: false
 
-image_pyramid:
-    description: Image Pyramid
+DART-FISH:
+    description: ????
+    alt-names: []
+    primary: true
+
+#image_pyramid:
+#    description: Image Pyramid
+
 IMC:
     description: Imaging Mass Cytometry
+    alt-names: []
+    primary: true
+
+IMC_pyramid:
+    description: Imaging Mass Cytometry [Image Pyramid]
+    alt-names: []
+    primary: false
 
 lc-ms_label-free:
     description: Label-free LC-MS
+    alt-names: []
+    primary: true
+
 lc-ms_labeled:
     description: Labeled LC-MS
+    alt-names: []
+    primary: true
+
 lc-ms-ms_label-free:
     description: Label-free LC-MS/MS
+    alt-names: []
+    primary: true
+
 lc-ms-ms_labeled:
     description: Labeled LC-MS/MS
+    alt-names: []
+    primary: true
+
+LC-MS-untargeted:
+    description: Untargeted LC-MS
+    alt-names: []
+    primary: true
 
 Lightsheet:
     description: Lightsheet Microscopy
+    alt-names: []
+    primary: true
+
 MALDI-IMS-neg:
     description: MALDI IMS negative
+    alt-names: []
+    primary: true
+
+MALDI-IMS-neg_pyramid:
+    description: MALDI IMS negative [Image Pyramid]
+    alt-names: []
+    primary: false
+
 MALDI-IMS-pos:
     description: MALDI IMS positive
+    alt-names: []
+    primary: true
+
+MALDI-IMS-pos_pyramid:
+    description: MALDI IMS positive [Image Pyramid]
+    alt-names: []
+    primary: false
+
 MxIF:
     description: Multiplexed IF Microscopy
+    alt-names: []
+    primary: true
+
+MxIF_pyramid:
+    description: Multiplexed IF Microscopy [Image Pyramid]
+    alt-names: []
+    primary: false
+
 PAS:
     description: PAS Stained Microscopy
+    alt-names: []
+    primary: true
+    
+PAS_pyramid:
+    description: PAS Stained Microscopy [Image Pyramid]
+    alt-names: [["PAS", "Image Pyramid"], ["Image Pyramid", "PAS"]]
+    primary: false    
+
+RNAseq-bulk:
+    description: Bulk RNA-seq
+    alt-names: [bulk-RNA]
+    primary: true
+
+RNAseq-bulk_salmon:
+    description: Bulk RNA-seq [Salmon]
+    alt-names: [salmon_rnaseq_bulk]
+    primary: false
+
 SNAREseq:
     description: SNARE-seq
-TMT-LC-MS:
-    description: TMT LC-MS
-Targeted-Shotgun-LC-MS:
-    description: Targeted Shotgun / Flow-injection LC-MS
-LC-MS-untargeted:
-    description: Untargeted LC-MS
-WGS:
-    description: Whole Genome Sequencing
+    alt-names: []
+    primary: true
 
-sc_atac_seq_snare_lab:
+SNAREseq_lab:
     description: scATAC-seq (SNARE-seq) [Lab Processed]
-sc_atac_seq_snare:
+    alt-names: [sc_atac_seq_snare_lab]
+    primary: true
+
+SNAREseq_snapATAC:
     description: scATAC-seq (SNARE-seq) [SnapATAC]
+    alt-names: [sc_atac_seq_snare]
+    primary: false
 
 scRNA-Seq-10x:
     description: scRNA-seq (10x Genomics)
+    alt-names: []
+    primary: true
+
 salmon_rnaseq_10x:
     description: scRNA-seq (10x Genomics) [Salmon]
+    alt-names: []
+    primary: false
 
 sc_rna_seq_snare_lab:
     description: snRNA-seq (SNARE-seq) [Lab Processed]
+    alt-names: []
+    primary: true
+
 salmon_rnaseq_snareseq:
     description: snRNA-seq (SNARE-seq) [Salmon]
+    alt-names: []
+    primary: false
 
 sciATACseq:
     description: sciATAC-seq
+    alt-names: []
+    primary: true
+
 sc_atac_seq_sci:
     description: sciATAC-seq [SnapATAC]
+    alt-names: []
+    primary: true
 
 sciRNAseq:
     description: sciRNA-seq
+    alt-names: []
+    primary: true
+
 salmon_rnaseq_sciseq:
     description: sciRNA-seq [Salmon]
+    alt-names: []
+    primary: false
 
 seqFish:
     description: seqFISH
+    alt-names: []
+    primary: true
+
+seqFish_pyramid:
+    description: seqFISH [Image Pyramid]
+    alt-names: []
+    primary: true
+
 seqFish_lab_processed:
     description: seqFISH [Lab Processed]
+    alt-names: []
+    primary: true
 
 snATACseq:
     description: snATAC-seq
-sn_atac_seq:
+    alt-names: []
+    primary: true
+
+snATACseq_snapATAC:
     description: snATAC-seq [SnapATAC]
+    alt-names: [sn_atac_seq]
+    primary: false
 
 snRNAseq:
     description: snRNA-seq
+    alt-names: []
+    primary: true
+
 salmon_sn_rnaseq_10x:
     description: snRNA-seq [Salmon]
+    alt-names: []
+    primary: false
+Slide-seq:
+    description: ????
+    alt-names: []
+    primary: true
+
+Targeted-Shotgun-LC-MS:
+    description: Targeted Shotgun / Flow-injection LC-MS
+    alt-names: []
+    primary: true
+
+TMT-LC-MS:
+    description: TMT LC-MS
+    alt-names: []
+    primary: true
+
+WGS:
+    description: Whole Genome Sequencing
+    alt-names: []
+    primary: true
+
+    

--- a/src/search-schema/data/definitions/enums/assay_types.yaml
+++ b/src/search-schema/data/definitions/enums/assay_types.yaml
@@ -152,7 +152,7 @@ sc_atac_seq_snare_lab:
     description: scATAC-seq (SNARE-seq) [Lab Processed]
 #    alt-names: [sc_atac_seq_snare_lab]
     alt-names: []
-    primary: true
+    primary: false
 
 sc_atac_seq_snare:
 #SNAREseq_snapATAC:
@@ -176,7 +176,7 @@ salmon_rnaseq_10x:
 sc_rna_seq_snare_lab:
     description: snRNA-seq (SNARE-seq) [Lab Processed]
     alt-names: []
-    primary: true
+    primary: false
 
 salmon_rnaseq_snareseq:
     description: snRNA-seq (SNARE-seq) [Salmon]
@@ -216,7 +216,7 @@ seqFish:
 seqFish_lab_processed:
     description: seqFISH [Lab Processed]
     alt-names: []
-    primary: true
+    primary: false
 
 snATACseq:
     description: snATAC-seq

--- a/src/search-schema/data/definitions/enums/assay_types.yaml
+++ b/src/search-schema/data/definitions/enums/assay_types.yaml
@@ -6,25 +6,27 @@ AF:
     alt-names: []
     primary: true
 
-AF_pyramid:
-    description: Autofluorescence Microscopy [Image Pyramid]
-    alt-names: [["AF", "Image Pyramid"], ["Image Pyramid", "AF"]]
-    primary: false
+# AF_pyramid:
+#     description: Autofluorescence Microscopy [Image Pyramid]
+#     alt-names: [["AF", "Image Pyramid"], ["Image Pyramid", "AF"]]
+#     primary: false
 
 ATACseq-bulk:
     description: Bulk ATAC-seq
     alt-names: []
     primary: true
 
-ATACseq-bulk_BWA_MACS2:
+bulk_atacseq:
+#ATACseq-bulk_BWA_MACS2:
     description: Bulk ATAC-seq [BWA + MACS2]
-    alt-names: [bulk-atacseq]
+#    alt-names: [bulk-atacseq]
+    alt-names: []
     primary: false
 
-cellDIVE:
-    description: ????
-    alt-names: []
-    primary: true
+# cellDIVE:
+#     description: ????
+#     alt-names: []
+#     primary: true
 
 CODEX:
     description: CODEX
@@ -36,23 +38,25 @@ codex_cytokit:
     alt-names: []
     primary: false
 
-DART-FISH:
-    description: ????
+# DART-FISH:
+#     description: ????
+#     alt-names: []
+#     primary: true
+
+image_pyramid:
+    description: Image Pyramid
     alt-names: []
-    primary: true
-
-#image_pyramid:
-#    description: Image Pyramid
-
+    primary: false
+    
 IMC:
     description: Imaging Mass Cytometry
     alt-names: []
     primary: true
 
-IMC_pyramid:
-    description: Imaging Mass Cytometry [Image Pyramid]
-    alt-names: []
-    primary: false
+# IMC_pyramid:
+#     description: Imaging Mass Cytometry [Image Pyramid]
+#     alt-names: []
+#     primary: false
 
 lc-ms_label-free:
     description: Label-free LC-MS
@@ -89,49 +93,53 @@ MALDI-IMS-neg:
     alt-names: []
     primary: true
 
-MALDI-IMS-neg_pyramid:
-    description: MALDI IMS negative [Image Pyramid]
-    alt-names: []
-    primary: false
+#MALDI-IMS-neg_pyramid:
+#    description: MALDI IMS negative [Image Pyramid]
+#    alt-names: [["MALDI-IMS-neg", "Image Pyramid"], ["Image Pyramid", "MALDI-IMS-neg"]]
+#    primary: false
 
 MALDI-IMS-pos:
     description: MALDI IMS positive
     alt-names: []
     primary: true
 
-MALDI-IMS-pos_pyramid:
-    description: MALDI IMS positive [Image Pyramid]
-    alt-names: []
-    primary: false
+# MALDI-IMS-pos_pyramid:
+#     description: MALDI IMS positive [Image Pyramid]
+#     alt-names: [["MALDI-IMS-pos", "Image Pyramid"], ["Image Pyramid", "MALDI-IMS-pos"]]
+#     primary: false
 
 MxIF:
     description: Multiplexed IF Microscopy
     alt-names: []
     primary: true
 
-MxIF_pyramid:
-    description: Multiplexed IF Microscopy [Image Pyramid]
-    alt-names: []
-    primary: false
+# MxIF_pyramid:
+#     description: Multiplexed IF Microscopy [Image Pyramid]
+#     alt-names: [["MxIF", "Image Pyramid"], ["Image Pyramid", "MxIF"]]
+#     primary: false
 
 PAS:
     description: PAS Stained Microscopy
     alt-names: []
     primary: true
     
-PAS_pyramid:
-    description: PAS Stained Microscopy [Image Pyramid]
-    alt-names: [["PAS", "Image Pyramid"], ["Image Pyramid", "PAS"]]
-    primary: false    
+# PAS_pyramid:
+#     description: PAS Stained Microscopy [Image Pyramid]
+#     alt-names: [["PAS", "Image Pyramid"], ["Image Pyramid", "PAS"]]
+#     primary: false    
 
-RNAseq-bulk:
+bulk-RNA:
+#RNAseq-bulk:
     description: Bulk RNA-seq
-    alt-names: [bulk-RNA]
+#    alt-names: [bulk-RNA]
+    alt-names: []
     primary: true
 
-RNAseq-bulk_salmon:
+salmon_rnaseq_bulk:
+#RNAseq-bulk_salmon:
     description: Bulk RNA-seq [Salmon]
-    alt-names: [salmon_rnaseq_bulk]
+#    alt-names: [salmon_rnaseq_bulk]
+    alt-names: []
     primary: false
 
 SNAREseq:
@@ -139,14 +147,18 @@ SNAREseq:
     alt-names: []
     primary: true
 
-SNAREseq_lab:
+sc_atac_seq_snare_lab:
+#SNAREseq_lab:
     description: scATAC-seq (SNARE-seq) [Lab Processed]
-    alt-names: [sc_atac_seq_snare_lab]
+#    alt-names: [sc_atac_seq_snare_lab]
+    alt-names: []
     primary: true
 
-SNAREseq_snapATAC:
+sc_atac_seq_snare:
+#SNAREseq_snapATAC:
     description: scATAC-seq (SNARE-seq) [SnapATAC]
-    alt-names: [sc_atac_seq_snare]
+#    alt-names: [sc_atac_seq_snare]
+    alt-names: []
     primary: false
 
 scRNA-Seq-10x:
@@ -155,7 +167,9 @@ scRNA-Seq-10x:
     primary: true
 
 salmon_rnaseq_10x:
+#scRNA-Seq-10x_salmon
     description: scRNA-seq (10x Genomics) [Salmon]
+#    alt-names: [salmon_rnaseq_10x]
     alt-names: []
     primary: false
 
@@ -194,10 +208,10 @@ seqFish:
     alt-names: []
     primary: true
 
-seqFish_pyramid:
-    description: seqFISH [Image Pyramid]
-    alt-names: []
-    primary: true
+# seqFish_pyramid:
+#     description: seqFISH [Image Pyramid]
+#     alt-names: []
+#     primary: true
 
 seqFish_lab_processed:
     description: seqFISH [Lab Processed]
@@ -209,9 +223,11 @@ snATACseq:
     alt-names: []
     primary: true
 
-snATACseq_snapATAC:
+sn_atac_seq:
+#snATACseq_snapATAC:
     description: snATAC-seq [SnapATAC]
-    alt-names: [sn_atac_seq]
+#    alt-names: [sn_atac_seq]
+    alt-names: []
     primary: false
 
 snRNAseq:
@@ -223,10 +239,11 @@ salmon_sn_rnaseq_10x:
     description: snRNA-seq [Salmon]
     alt-names: []
     primary: false
-Slide-seq:
-    description: ????
-    alt-names: []
-    primary: true
+
+# Slide-seq:
+#     description: ????
+#     alt-names: []
+#     primary: true
 
 Targeted-Shotgun-LC-MS:
     description: Targeted Shotgun / Flow-injection LC-MS

--- a/test.sh
+++ b/test.sh
@@ -4,3 +4,4 @@ set -o errexit
 ./generate-build-version.sh
 src/elasticsearch/addl_index_transformations/portal/test.sh
 src/search-schema/test.sh
+src/libs/test.sh


### PR DESCRIPTION
This update introduces lib/assay_types.py with class AssayTypes, and adds REST entry points to provide assay type info to search-api.  Assay types gain a 'primary' attribute for use by ingest-ui in distinguishing those that can be submitted datasets, and an alt-names list to support deprecating assay names in favor of updated names.  assay_types.yaml gets a schema.