### PR TITLE
For debugging purposes, let transforms be run from commandline

### DIFF
--- a/src/elasticsearch/addl_index_transformations/portal/__init__.py
+++ b/src/elasticsearch/addl_index_transformations/portal/__init__.py
@@ -1,3 +1,4 @@
+import argparse
 from pathlib import Path
 from copy import deepcopy
 import logging
@@ -272,3 +273,16 @@ def _as_path_string(mixed):
     '''
     sep = '/'
     return sep + sep.join(str(s) for s in mixed)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description='Given a source document, transform it.'
+    )
+
+    parser.add_argument('input', type=argparse.FileType('r'), help='Path of input YAML/JSON.')
+    args = parser.parse_args()
+    input_yaml = args.input.read()
+    doc = load_yaml(input_yaml)
+    transformed = transform(doc)
+    print(dumps(transformed, sort_keys=True, indent=2))

--- a/src/elasticsearch/addl_index_transformations/portal/test.sh
+++ b/src/elasticsearch/addl_index_transformations/portal/test.sh
@@ -19,3 +19,13 @@ for F in elasticsearch/addl_index_transformations/portal/*.py; do
 done
 cd -
 end portal/doctests
+
+start portal/cli
+cd ../../../..
+PYTHONPATH="src:$PYTHONPATH" \
+  python src/elasticsearch/addl_index_transformations/portal/__init__.py \
+  src/elasticsearch/addl_index_transformations/portal/tests/fixtures/input-doc.json \
+  | grep '"entity_type": "dataset"'
+  # Doctest covers the details: Just want to make sure it runs.
+cd -
+end portal/cli

--- a/src/elasticsearch/addl_index_transformations/portal/tests/fixtures/input-doc.json
+++ b/src/elasticsearch/addl_index_transformations/portal/tests/fixtures/input-doc.json
@@ -1,0 +1,33 @@
+{
+    "entity_type": "dataset",
+    "status": "New",
+    "origin_sample": {
+        "organ": "LY01"
+    },
+    "create_timestamp": 1575489509656,
+    "ancestor_ids": ["1234", "5678"],
+    "ancestors": [{
+        "specimen_type": "fresh_frozen_tissue_section",
+        "created_by_user_displayname": "daniel Cotter"
+    }],
+    "data_access_level": "consortium",
+    "data_types": ["codex_cytokit", "seqFish"],
+    "descendants": [{"entity_type": "Sample or Dataset"}],
+    "donor": {
+        "metadata": {
+            "organ_donor_data": [
+                {
+                    "data_type": "Nominal",
+                    "grouping_concept_preferred_term": "Sex",
+                    "preferred_term": "Male"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "metadata": {
+            "_random_stuff_that_should_not_be_ui": true,
+            "unrealistic": "Donors do not have metadata/metadata."
+        }
+    }
+}


### PR DESCRIPTION
For the next phase of work, I'll need to actually run the transforms during development, and the doctests won't be enough. This adds a `__name__ == "__main__"` block. Since it's not really useful for anyone else, I'm not worrying about the PYTHONPATH messiness, but that could change.