### PR TITLE
Remove reference to updating assay ontology doc

### DIFF
--- a/src/search-schema/data/definitions/enums/assay_types.yaml
+++ b/src/search-schema/data/definitions/enums/assay_types.yaml
@@ -1,8 +1,3 @@
-# When updating this document, please suggest a corresponding update to:
-# https://docs.google.com/document/d/1X4wpotexDmvPtUjIN8P5kOgqDGwk0aBLxJSXgSuNqnU/edit
-# Reference the PR in this repo, and '@' Elizabeth Neumann & Peter Kant
-# to incorporate the change into the the google doc.
-
 AF:
     description: Autofluorescence Microscopy
     alt-names: []


### PR DESCRIPTION
The referenced google doc is deprecated:

> THIS DOCUMENT IS DEPRECATED AS OF MARCH 8, 2021.  For a source of truth list of assays, please see the HuBMAP Portal or contact help@hubmapconsortium.org

Fix #246