### PR TITLE
Make the message more explicit when the translation is missing

### DIFF
--- a/src/elasticsearch/addl_index_transformations/portal/translate.py
+++ b/src/elasticsearch/addl_index_transformations/portal/translate.py
@@ -11,7 +11,7 @@ class TranslationException(Exception):
 
 
 def _unexpected(s):
-    return f'{{{s}}}'
+    return f'No translation for "{s}"'
 
 
 def translate(doc):
@@ -56,7 +56,7 @@ def _translate_access_level(doc):
     {'data_access_level': 'consortium', 'mapped_data_access_level': 'Consortium'}
     >>> doc = {'data_access_level': 'top-secret'}
     >>> _translate_access_level(doc); doc
-    {'data_access_level': 'top-secret', 'mapped_data_access_level': '{top-secret}'}
+    {'data_access_level': 'top-secret', 'mapped_data_access_level': 'No translation for "top-secret"'}
 
     '''
     _map(doc, 'data_access_level', _access_level_map)
@@ -106,7 +106,7 @@ def _translate_status(doc):
 
     >>> doc = {'status': 'Foobar'}
     >>> _translate_status(doc); doc
-    {'status': 'Foobar', 'mapped_status': '{Foobar}'}
+    {'status': 'Foobar', 'mapped_status': 'No translation for "Foobar"'}
     '''
     _map(doc, 'status', _status_map)
 
@@ -131,7 +131,7 @@ def _translate_organ(doc):
 
     >>> doc = {'origin_sample': {'organ': 'ZZ'}}
     >>> _translate_organ(doc); doc
-    {'origin_sample': {'organ': 'ZZ', 'mapped_organ': '{ZZ}'}}
+    {'origin_sample': {'organ': 'ZZ', 'mapped_organ': 'No translation for "ZZ"'}}
 
     '''
     _map(doc, 'organ', _organ_map)
@@ -159,7 +159,7 @@ def _translate_specimen_type(doc):
 
     >>> doc = {'specimen_type': 'xyz'}
     >>> _translate_specimen_type(doc); doc
-    {'specimen_type': 'xyz', 'mapped_specimen_type': '{xyz}'}
+    {'specimen_type': 'xyz', 'mapped_specimen_type': 'No translation for "xyz"'}
 
     '''
     _map(doc, 'specimen_type', _specimen_types_map)
@@ -191,7 +191,7 @@ def _translate_data_type(doc):
 
     >>> doc = {'data_types': ['xyz', 'abc', 'image_pyramid']}
     >>> _translate_data_type(doc); doc
-    {'data_types': ['xyz', 'abc', 'image_pyramid'], 'mapped_data_types': ['{abc} / {xyz} [Image Pyramid]']}
+    {'data_types': ['xyz', 'abc', 'image_pyramid'], 'mapped_data_types': ['No translation for "abc" / No translation for "xyz" [Image Pyramid]']}
 
     '''
     _map(doc, 'data_types', _data_types_map)


### PR DESCRIPTION
I had totally forgotten where the curly braces come from. My sense is that:
- We identified a small gap in the process, and it will become clear who has responsibility for supplying missing translations going forward.
- If "DART-FISH" is "DART-FISH", great: It just needs to be explicit.
- It's not the end of the world for these to show up sometimes on unpublished data ... Erroring out would be too aggressive?
- Nothing else I need to do here.