### PR TITLE
The sc_atac_seq_sci datatype is derived from sciATACseq and not 'prim…

### DIFF
--- a/examples/libs/assay_type_out.txt
+++ b/examples/libs/assay_type_out.txt
@@ -60,6 +60,7 @@ non-primary names:
 - salmon_rnaseq_sciseq
 - salmon_rnaseq_snareseq
 - salmon_sn_rnaseq_10x
+- sc_atac_seq_sci
 - sc_atac_seq_snare
 - sc_atac_seq_snare_lab
 - sc_rna_seq_snare_lab
@@ -90,7 +91,6 @@ primary names:
 - lc-ms_label-free
 - lc-ms_labeled
 - scRNA-Seq-10x
-- sc_atac_seq_sci
 - sciATACseq
 - sciRNAseq
 - seqFish

--- a/src/search-schema/data/definitions/enums/assay_types.yaml
+++ b/src/search-schema/data/definitions/enums/assay_types.yaml
@@ -228,7 +228,7 @@ sciATACseq:
 sc_atac_seq_sci:
     description: sciATAC-seq [SnapATAC]
     alt-names: []
-    primary: true
+    primary: false
     vitessce-hints: ['is_sc', 'atac']
 
 sciRNAseq:


### PR DESCRIPTION
…ary'

assay_types.yaml controls the definitions of assay types and datasets derived from assays.  The entry for sc_atac_seq_sci was incorrectly marked as primary.