### PR TITLE
Remove duplicate sequence_library

### DIFF
--- a/src/search-schema/data/definitions/enums/tissue_sample_types.yaml
+++ b/src/search-schema/data/definitions/enums/tissue_sample_types.yaml
@@ -80,8 +80,6 @@ sequence_library:
   description: Sequence library
 serum:
   description: Serum
-sequence_library:
-  description: Sequence Library
 single_cell_cryopreserved:
   description: Single cell cryopreserved
 snatacseq:


### PR DESCRIPTION
Remove the duplicated entry:

````
sequence_library:
  description: Sequence Library
````

Only keep the following with description of `Sequence library` to be consistent with the rest, letter case-wise.

````
sequence_library:
  description: Sequence library
````