### PR TITLE
Change back to entity['source_sample'] = parents

### DIFF
--- a/src/elasticsearch/indexer.py
+++ b/src/elasticsearch/indexer.py
@@ -543,7 +543,8 @@ class Indexer:
                         try:
                             # Why?
                             if parents[0]['entity_type'] == 'Sample':
-                                entity['source_sample'] = parents[0]
+                                #entity['source_sample'] = parents[0]
+                                entity['source_sample'] = parents
 
                             e = parents[0]
                         except IndexError:


### PR DESCRIPTION
To fix full reindex error like below:
````
[2021-05-24 17:06:22] INFO in indexer: ############# Full index via script started #############
[2021-05-24 17:06:22] DEBUG in connectionpool: Starting new HTTPS connection (1): search-hubmap-entity-es-stage-4fverclzhxn7lz56yakpyfwkpy.us-east-1.es.amazonaws.com:443
[2021-05-24 17:06:22] DEBUG in connectionpool: https://search-hubmap-entity-es-stage-4fverclzhxn7lz56yakpyfwkpy.us-east-1.es.amazonaws.com:443 "DELETE /hm_public_entities HTTP/1.1" 200 21
[2021-05-24 17:06:22] INFO in es_writer: Deleted index: hm_public_entities
[2021-05-24 17:06:22] DEBUG in connectionpool: Starting new HTTPS connection (1): search-hubmap-entity-es-stage-4fverclzhxn7lz56yakpyfwkpy.us-east-1.es.amazonaws.com:443
[2021-05-24 17:06:22] DEBUG in connectionpool: https://search-hubmap-entity-es-stage-4fverclzhxn7lz56yakpyfwkpy.us-east-1.es.amazonaws.com:443 "PUT /hm_public_entities HTTP/1.1" 200 77
[2021-05-24 17:06:22] INFO in es_writer: Created index: hm_public_entities
[2021-05-24 17:06:22] DEBUG in connectionpool: Starting new HTTPS connection (1): search-hubmap-entity-es-stage-4fverclzhxn7lz56yakpyfwkpy.us-east-1.es.amazonaws.com:443
[2021-05-24 17:06:23] DEBUG in connectionpool: https://search-hubmap-entity-es-stage-4fverclzhxn7lz56yakpyfwkpy.us-east-1.es.amazonaws.com:443 "DELETE /hm_consortium_entities HTTP/1.1" 200 21
[2021-05-24 17:06:23] INFO in es_writer: Deleted index: hm_consortium_entities
[2021-05-24 17:06:23] DEBUG in connectionpool: Starting new HTTPS connection (1): search-hubmap-entity-es-stage-4fverclzhxn7lz56yakpyfwkpy.us-east-1.es.amazonaws.com:443
[2021-05-24 17:06:24] DEBUG in connectionpool: https://search-hubmap-entity-es-stage-4fverclzhxn7lz56yakpyfwkpy.us-east-1.es.amazonaws.com:443 "PUT /hm_consortium_entities HTTP/1.1" 200 81
[2021-05-24 17:06:24] INFO in es_writer: Created index: hm_consortium_entities
[2021-05-24 17:06:24] DEBUG in connectionpool: Starting new HTTPS connection (1): search-hubmap-entity-es-stage-4fverclzhxn7lz56yakpyfwkpy.us-east-1.es.amazonaws.com:443
[2021-05-24 17:06:24] DEBUG in connectionpool: https://search-hubmap-entity-es-stage-4fverclzhxn7lz56yakpyfwkpy.us-east-1.es.amazonaws.com:443 "DELETE /hm_public_portal HTTP/1.1" 200 21
[2021-05-24 17:06:24] INFO in es_writer: Deleted index: hm_public_portal
[2021-05-24 17:06:24] DEBUG in connectionpool: Starting new HTTPS connection (1): search-hubmap-entity-es-stage-4fverclzhxn7lz56yakpyfwkpy.us-east-1.es.amazonaws.com:443
[2021-05-24 17:06:24] DEBUG in connectionpool: https://search-hubmap-entity-es-stage-4fverclzhxn7lz56yakpyfwkpy.us-east-1.es.amazonaws.com:443 "PUT /hm_public_portal HTTP/1.1" 200 75
[2021-05-24 17:06:24] INFO in es_writer: Created index: hm_public_portal
[2021-05-24 17:06:24] DEBUG in connectionpool: Starting new HTTPS connection (1): search-hubmap-entity-es-stage-4fverclzhxn7lz56yakpyfwkpy.us-east-1.es.amazonaws.com:443
[2021-05-24 17:06:24] DEBUG in connectionpool: https://search-hubmap-entity-es-stage-4fverclzhxn7lz56yakpyfwkpy.us-east-1.es.amazonaws.com:443 "DELETE /hm_consortium_portal HTTP/1.1" 200 21
[2021-05-24 17:06:24] INFO in es_writer: Deleted index: hm_consortium_portal
[2021-05-24 17:06:24] DEBUG in connectionpool: Starting new HTTPS connection (1): search-hubmap-entity-es-stage-4fverclzhxn7lz56yakpyfwkpy.us-east-1.es.amazonaws.com:443
[2021-05-24 17:06:25] DEBUG in connectionpool: https://search-hubmap-entity-es-stage-4fverclzhxn7lz56yakpyfwkpy.us-east-1.es.amazonaws.com:443 "PUT /hm_consortium_portal HTTP/1.1" 200 79
[2021-05-24 17:06:25] INFO in es_writer: Created index: hm_consortium_portal
[2021-05-24 17:06:25] DEBUG in connectionpool: Starting new HTTP connection (1): hubmap-auth:3333
[2021-05-24 17:06:29] DEBUG in connectionpool: http://hubmap-auth:3333 "GET /collections HTTP/1.1" 200 58003
[2021-05-24 17:06:29] DEBUG in connectionpool: Starting new HTTP connection (1): hubmap-auth:3333
[2021-05-24 17:06:31] DEBUG in connectionpool: http://hubmap-auth:3333 "GET /collections/4964d24bbc6668a72c4cbb5e0393a6bc HTTP/1.1" 200 152023
[2021-05-24 17:06:31] DEBUG in connectionpool: Starting new HTTP connection (1): hubmap-auth:3333
[2021-05-24 17:06:31] DEBUG in connectionpool: http://hubmap-auth:3333 "GET /entities/8d649002964c5c599b84ef38cac91410 HTTP/1.1" 200 9960
[2021-05-24 17:06:31] DEBUG in connectionpool: Starting new HTTP connection (1): hubmap-auth:3333
[2021-05-24 17:06:32] DEBUG in connectionpool: http://hubmap-auth:3333 "GET /ancestors/8d649002964c5c599b84ef38cac91410 HTTP/1.1" 200 5173
[2021-05-24 17:06:32] DEBUG in connectionpool: Starting new HTTP connection (1): hubmap-auth:3333
[2021-05-24 17:06:32] DEBUG in connectionpool: http://hubmap-auth:3333 "GET /ancestors/8d649002964c5c599b84ef38cac91410?property=uuid HTTP/1.1" 200 142
[2021-05-24 17:06:32] DEBUG in connectionpool: Starting new HTTP connection (1): hubmap-auth:3333
[2021-05-24 17:06:33] DEBUG in connectionpool: http://hubmap-auth:3333 "GET /descendants/8d649002964c5c599b84ef38cac91410 HTTP/1.1" 200 1962
[2021-05-24 17:06:33] DEBUG in connectionpool: Starting new HTTP connection (1): hubmap-auth:3333
[2021-05-24 17:06:33] DEBUG in connectionpool: http://hubmap-auth:3333 "GET /descendants/8d649002964c5c599b84ef38cac91410?property=uuid HTTP/1.1" 200 37
[2021-05-24 17:06:33] DEBUG in connectionpool: Starting new HTTP connection (1): hubmap-auth:3333
[2021-05-24 17:06:33] DEBUG in connectionpool: http://hubmap-auth:3333 "GET /parents/8d649002964c5c599b84ef38cac91410 HTTP/1.1" 200 579
[2021-05-24 17:06:33] DEBUG in connectionpool: Starting new HTTP connection (1): hubmap-auth:3333
[2021-05-24 17:06:33] DEBUG in connectionpool: http://hubmap-auth:3333 "GET /children/8d649002964c5c599b84ef38cac91410 HTTP/1.1" 200 1962
[2021-05-24 17:06:33] DEBUG in connectionpool: Starting new HTTP connection (1): hubmap-auth:3333
[2021-05-24 17:06:33] DEBUG in connectionpool: http://hubmap-auth:3333 "GET /parents/8d649002964c5c599b84ef38cac91410 HTTP/1.1" 200 579
[2021-05-24 17:06:33] INFO in globus_groups: Globus groups json file loaded successfully
[2021-05-24 17:06:33] ERROR in indexer: Exceptions during executing indexer.generate_doc()
Traceback (most recent call last):
  File "/usr/src/app/src/elasticsearch/indexer.py", line 586, in generate_doc
    self.entity_keys_rename(s)
  File "/usr/src/app/src/elasticsearch/indexer.py", line 711, in entity_keys_rename
    entity.pop(key)
AttributeError: 'str' object has no attribute 'pop'
[2021-05-24 17:06:33] ERROR in indexer: Exception encountered during executing indexer.main()
Traceback (most recent call last):
  File "/usr/src/app/src/elasticsearch/indexer.py", line 112, in main
    self.index_public_collections()
  File "/usr/src/app/src/elasticsearch/indexer.py", line 190, in index_public_collections
    self.add_datasets_to_collection(collection)
  File "/usr/src/app/src/elasticsearch/indexer.py", line 838, in add_datasets_to_collection
    dataset_doc.pop('ancestors')
AttributeError: 'NoneType' object has no attribute 'pop'
[2021-05-24 17:06:33] INFO in indexer: ############# Full index via script completed. Total time used: 11.296298742294312 seconds. #############
````