### PR TITLE
Resolve ambiguities in assay naming for cell-dive

### DIFF
--- a/src/search-schema/data/definitions/enums/assay_types.yaml
+++ b/src/search-schema/data/definitions/enums/assay_types.yaml
@@ -31,7 +31,7 @@ bulk_atacseq:
 
 cell-dive:
     description: Cell DIVE
-    alt-names: []
+    alt-names: ["cell DIVE", "Cell DIVE"]
     primary: true
     contains-pii: false
 


### PR DESCRIPTION
The Cell DIVE assay goes by "cell-dive", "Cell DIVE", and "cell DIVE" in various places. This PR makes "cell-dive" the standard string (because it is one word) and defines the other two as deprecated alt names.  The visible description of the assay does not change.

Sorry, accidentally pushed this to what should have been a dead branch.