### PR TITLE
Use new JSON-LD for anatomy

### DIFF
--- a/src/elasticsearch/addl_index_transformations/portal/__init__.py
+++ b/src/elasticsearch/addl_index_transformations/portal/__init__.py
@@ -95,9 +95,8 @@ def transform(doc, batch_id='unspecified'):
     >>> del transformed['mapper_metadata']
     >>> pprint(transformed)
     {'anatomy_0': 'body',
-     'anatomy_1': 'abdominal cavity',
-     'anatomy_2': 'colon',
-     'anatomy_3': 'transverse colon',
+     'anatomy_1': 'large intestine',
+     'anatomy_2': 'transverse colon',
      'ancestor_counts': {'entity_type': {}},
      'ancestor_ids': ['1234', '5678'],
      'ancestors': [{'created_by_user_displayname': 'Daniel Cotter',

--- a/src/elasticsearch/addl_index_transformations/portal/__init__.py
+++ b/src/elasticsearch/addl_index_transformations/portal/__init__.py
@@ -57,7 +57,7 @@ def transform(doc, batch_id='unspecified'):
     ...    'entity_type': 'dataset',
     ...    'status': 'New',
     ...    'origin_sample': {
-    ...        'organ': 'LY01'
+    ...        'organ': 'LY'
     ...    },
     ...    'create_timestamp': 1575489509656,
     ...    'ancestor_ids': ['1234', '5678'],
@@ -119,7 +119,7 @@ def transform(doc, batch_id='unspecified'):
      'mapped_metadata': {},
      'mapped_status': 'New',
      'metadata': {'metadata': {'keep_this_field': 'Yes!'}},
-     'origin_sample': {'mapped_organ': 'Lymph Node', 'organ': 'LY01'},
+     'origin_sample': {'mapped_organ': 'Lymph Node', 'organ': 'LY'},
      'rui_location': '{"ccf_annotations": '
                      '["http://purl.obolibrary.org/obo/UBERON_0001157"]}',
      'status': 'New'}

--- a/src/elasticsearch/addl_index_transformations/portal/add_partonomy.py
+++ b/src/elasticsearch/addl_index_transformations/portal/add_partonomy.py
@@ -18,7 +18,7 @@ def add_partonomy(doc):
     >>> add_partonomy(doc)
     >>> del doc['rui_location']
     >>> doc
-    {'anatomy_0': 'body', 'anatomy_1': 'abdominal cavity', 'anatomy_2': 'colon', 'anatomy_3': 'transverse colon'}
+    {'anatomy_0': 'body', 'anatomy_1': 'large intestine', 'anatomy_2': 'transverse colon'}
 
     '''
     if 'rui_location' not in doc:
@@ -57,10 +57,37 @@ def _build_tree_index():
     Returns a tuple:
         - A tree, where each node has value, parent_id, and children.
         - A dict indexing into every node of the tree by id.
+
+    >>> tree, index = _build_tree_index()
+    >>> from pprint import pprint
+    >>> pprint(tree, depth=1)
+    {'children': [...], 'parent_id': None, 'value': 'body'}
+    >>> pprint(sorted([child['value'] for child in tree['children']]))
+    ['blood',
+     'bone marrow',
+     'brain',
+     'heart',
+     'kidney',
+     'kidney vasculature',
+     'large intestine',
+     'lymph node',
+     'pelvis',
+     'respiratory system',
+     'retromandibular vein',
+     'skin',
+     'spleen',
+     'spleen',
+     'spleen',
+     'telencephalic ventricle',
+     'thymus']
+    >>> pprint(index['http://purl.obolibrary.org/obo/UBERON_0000029'], depth=1)
+    {'children': [...],
+     'parent_id': 'http://purl.obolibrary.org/obo/UBERON_0013702',
+     'value': 'lymph node'}
     '''
-    partonomy_path = Path(__file__).parent / 'cache/partonomy.jsonld'
+    partonomy_path = Path(__file__).parent / 'cache/partonomy-1.6.0.jsonld'
     if not partonomy_path.exists():
-        partonomy_url = 'https://cdn.jsdelivr.net/gh/hubmapconsortium/hubmap-ontology@1.0.0/ccf-partonomy.jsonld'
+        partonomy_url = 'https://cdn.jsdelivr.net/gh/hubmapconsortium/hubmap-ontology@1.6.0/ccf-partonomy.jsonld'
         partonomy_path.write_text(requests.get(partonomy_url).text)
 
     partonomy_ld = loads(partonomy_path.read_text())

--- a/src/elasticsearch/addl_index_transformations/portal/tests/fixtures/input-doc.json
+++ b/src/elasticsearch/addl_index_transformations/portal/tests/fixtures/input-doc.json
@@ -2,7 +2,7 @@
     "entity_type": "dataset",
     "status": "New",
     "origin_sample": {
-        "organ": "LY01"
+        "organ": "LY"
     },
     "create_timestamp": 1575489509656,
     "ancestor_ids": ["1234", "5678"],

--- a/src/elasticsearch/addl_index_transformations/portal/translate.py
+++ b/src/elasticsearch/addl_index_transformations/portal/translate.py
@@ -148,10 +148,6 @@ def _status_map(status):
 
 def _translate_organ(doc):
     '''
-    >>> doc = {'organ': 'LY01'}
-    >>> _translate_organ(doc); doc
-    {'organ': 'LY01', 'mapped_organ': 'Lymph Node'}
-
     >>> doc = {'origin_sample': {'organ': 'RK'}}
     >>> _translate_organ(doc); doc
     {'origin_sample': {'organ': 'RK', 'mapped_organ': 'Kidney (Right)'}}
@@ -171,7 +167,7 @@ def _organ_map(k):
 
 
 _organ_dict = {
-    k: re.sub(r'\s+\d+$', '', v['description'])
+    k: v['description']
     for k, v in _enums['organ_types'].items()
 }
 


### PR DESCRIPTION
### Fix test failures

@yuanzhou / @shirey : I think this should address tests that have been failing since [Bill's commit last week](https://github.com/hubmapconsortium/search-api/commit/762f5aee70b7d59b98194617a57ec67440b80d49) that removed `LY01` etc., but I'm not sure, since CI still isn't running.

I think we're on the same page that moving forward, tests need to be passing before merging to `test-release`? In particular, this means that not even configuration changes should be made directly to `test-release` without PR: Even a configuration change can cause tests to fail. I also think that we're on that same page that it is the responsibility of the Pittsburgh team to keep the CI itself running, whichever service you want to use.

### Upgrade partonomy

@bherr2 : This upgrades the partonomy: It looks like there is good stuff in there, but I think there are still problems. The [top level of the tree](https://github.com/hubmapconsortium/search-api/pull/378/files#diff-55826f44f8623673cb436d1272f9e5a399197923412f52d750465f5d13b87888R76-R81) seems weird:
```
     ...
     'retromandibular vein',
     'skin',
     'spleen',
     'spleen',
     'spleen',
     'telencephalic ventricle',
     ....
```
- Why is `spleen` repeated?
- What's up with `retromandibular vein` and `telencephalic ventricle`? These don't seem like they belong at the top level.

Going forward, as there are new partonomy releases, I think it would make sense for Bruce to start PRs in this repo, and just loop me in as a reviewer if needed.


