### PR TITLE
Discussion re: Incorporating new LC-MS assay_types

### DIFF
--- a/src/search-schema/data/definitions/enums/assay_types.yaml
+++ b/src/search-schema/data/definitions/enums/assay_types.yaml
@@ -106,6 +106,8 @@ IMC3D_pyramid:
     contains-pii: false
     vitessce-hints: ['pyramid']
 
+##### Add 6 new lc-ms assay_types
+
 lc-ms_label-free:
     description: Label-free LC-MS
     alt-names: []


### PR DESCRIPTION
@jswelling @ropelews @mruffalo 
line 109

Joel requested opening this PR to conduct a discussion about this issue.

Description of the problem

The original assay_types are, as listed in this yaml:
-Label-free LC-MS
-Labeled LC-MS
-Label-free LC-MS/MS
-Labeled LC-MS/MS
-Untargeted LC-MS
-Targeted Shotgun / Flow-injection LC-MS
-TMT LC-MS

Per Jeannie Camarillo (Northwestern) , the new assay types are more broad and better define the analyte being analyzed.
Bottom-up: analyzing proteins are in a sample by digesting them to peptides
Top-down: analyzing whole proteins without digestion:
-LC-MS and MS are for lipids/metabolites
-LC-MS Bottom-Up and MS Bottom-Up are for peptides
-LC-MS Top-Down and MS Top-Down are for proteins

Next, I'll ask the submitters of the lcms datasets from 2020 which of the new assay_types apply to their datasets. Then we can decide on a strategy for accommodating the new assay_types in this yaml.