### PR TITLE
Command-line tool to debug rui facetting

### DIFF
--- a/src/elasticsearch/addl_index_transformations/portal/add_partonomy.py
+++ b/src/elasticsearch/addl_index_transformations/portal/add_partonomy.py
@@ -1,7 +1,8 @@
+import argparse
 from collections import defaultdict
 import requests
 from pathlib import Path
-from json import loads
+from json import loads, dumps
 from yaml import safe_load
 
 
@@ -174,3 +175,16 @@ def _build_tree_index():
 
 
 tree, index = _build_tree_index()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description='Given RUI-JSON, return the anatomy facets that will be generated.'
+    )
+
+    parser.add_argument('rui_json', help='RUI-JSON as string.')
+    args = parser.parse_args()
+    doc = {'rui_location': args.rui_json}
+    add_partonomy(doc)
+    del doc['rui_location']
+    print(dumps(doc, sort_keys=True, indent=2))


### PR DESCRIPTION
Towards https://github.com/hubmapconsortium/portal-ui/issues/2218

Taking annotations from the [spleen dataset linked from that issue](https://portal.hubmapconsortium.org/browse/sample/474657175c19641a1138d87f90d35fa5.json). I think the central problem is that the fine-scale UBERON terms can occur in different organ contexts, so we can't just walk up to the chain of parents to determine the organ.

This PR just makes the issue easier to debug. We shouldn't try to hash out a solution here.

cc @bherr2 / @ngehlenborg 

```
$ python src/elasticsearch/addl_index_transformations/portal/add_partonomy.py \
  '{"ccf_annotations": ["http://purl.obolibrary.org/obo/UBERON_0002049"]}'
{
  "anatomy_0": [
    "body"
  ],
  "anatomy_1": [
    "heart"
  ],
  "anatomy_2": [
    "right ventricle"
  ],
  "anatomy_3": [
    "vasculature"
  ]
}
```

```
python src/elasticsearch/addl_index_transformations/portal/add_partonomy.py \
  '{"ccf_annotations": ["http://purl.obolibrary.org/obo/UBERON_0010417"]}'
{
  "anatomy_0": [
    "body"
  ],
  "anatomy_1": [
    "lymph node"
  ],
  "anatomy_2": [
    "cortex"
  ],
  "anatomy_3": [
    "paracortex"
  ]
}
```

The spleen _is_ a lymphatic organ, so it probably does have many of the fine-scale features that we think of as part of lymph nodes... but in this case the context is different.
