### PR TITLE
Add support for scRNAseq-10xGenomics, -v2, and -v3

### DIFF
--- a/src/search-schema/data/definitions/enums/assay_types.yaml
+++ b/src/search-schema/data/definitions/enums/assay_types.yaml
@@ -394,16 +394,9 @@ sn_atac_seq:
     contains-pii: false
     vitessce-hints: ['is_sc', 'atac']
 
-snRNAseq-v2:
-    description: 'snRNA-seq (v2)'
+snRNAseq:
+    description: snRNA-seq
     alt-names: []
-    primary: true
-    contains-pii: true
-    vitessce-hints: []
-
-snRNAseq-v3:
-    description: 'snRNA-seq (v3)'
-    alt-names: ['snRNAseq']
     primary: true
     contains-pii: true
     vitessce-hints: []

--- a/src/search-schema/data/definitions/enums/assay_types.yaml
+++ b/src/search-schema/data/definitions/enums/assay_types.yaml
@@ -394,9 +394,16 @@ sn_atac_seq:
     contains-pii: false
     vitessce-hints: ['is_sc', 'atac']
 
-snRNAseq:
-    description: snRNA-seq
+snRNAseq-v2:
+    description: 'snRNA-seq (v2)'
     alt-names: []
+    primary: true
+    contains-pii: true
+    vitessce-hints: []
+
+snRNAseq-v3:
+    description: 'snRNA-seq (v3)'
+    alt-names: ['snRNAseq']
     primary: true
     contains-pii: true
     vitessce-hints: []

--- a/src/search-schema/data/definitions/enums/assay_types.yaml
+++ b/src/search-schema/data/definitions/enums/assay_types.yaml
@@ -302,9 +302,19 @@ sc_atac_seq_snare:
     contains-pii: false
     vitessce-hints: ['is_sc', 'atac']
 
-scRNA-Seq-10x:
-    description: scRNA-seq (10x Genomics)
-    alt-names: ['scRNA-Seq(10xGenomics)']
+scRNAseq-10xGenomics-v2:
+    description: scRNA-seq (10x Genomics v2)
+    alt-names: []
+    primary: true
+    contains-pii: true
+    vitessce-hints: []
+
+scRNAseq-10xGenomics-v3:
+    description: scRNA-seq (10x Genomics v3)
+    alt-names:
+      - scRNA-Seq(10xGenomics)
+      - scRNA-Seq-10x
+      - scRNAseq-10xGenomics
     primary: true
     contains-pii: true
     vitessce-hints: []


### PR DESCRIPTION
This PR adds support for the new assay type names scRNAseq-10xGenomics, scRNAseq-10xGenomics-v2, and scRNAseq-10xGenomics-v3 .  -v3 is assumed to be the common case, and thus replaces the old name scRNA-Seq-10x.  The version without the suffix is assumed to be a redundant name for that same assay.  The -v2 variant is assumed to be a new assay type.  

The derived dataset type produced from all of these by the salmon_rnaseq pipeline remains salmon-rnaseq_10x, so note that these two different primary assay types give rise to the same secondary dataset type.

In addition to this PR, these changes will require a PR against ingest-pipeline to update the workflow map and to set appropriate flags for processing -v2 data as having chromium-v2 tags.