### PR TITLE
Mccalluc/numbers should be numbers

### DIFF
--- a/src/elasticsearch/addl_index_transformations/portal/__init__.py
+++ b/src/elasticsearch/addl_index_transformations/portal/__init__.py
@@ -219,8 +219,6 @@ def _simple_clean(doc):
                 if v in ['1', 'true', 'True']:
                     metadata[k] = 'TRUE'
 
-        doc['metadata']['metadata'] = metadata
-
 # TODO: Reenable this when we have time, and can make sure we don't need these fields.
 #
 #     schema = _get_schema(doc)

--- a/src/elasticsearch/addl_index_transformations/portal/__init__.py
+++ b/src/elasticsearch/addl_index_transformations/portal/__init__.py
@@ -215,9 +215,12 @@ def _simple_clean(doc):
             # but at the moment it is the case.)
             if k.startswith('is_'):
                 if v in ['0', 'false', 'False']:
-                    metadata[k] = 'FALSE'
+                    metadata[k] = False
                 if v in ['1', 'true', 'True']:
-                    metadata[k] = 'TRUE'
+                    metadata[k] = True
+        # Other converstions are handled by ES numeric detection.
+        # See: portal/config.yaml
+        # https://www.elastic.co/guide/en/elasticsearch/reference/current/dynamic-field-mapping.html
 
 # TODO: Reenable this when we have time, and can make sure we don't need these fields.
 #

--- a/src/elasticsearch/addl_index_transformations/portal/config.yaml
+++ b/src/elasticsearch/addl_index_transformations/portal/config.yaml
@@ -5,6 +5,7 @@ settings:
 
 mappings:
   date_detection: False
+  numeric_detection: True
   dynamic_templates:
     -
       map_every_string:


### PR DESCRIPTION
- Fix #421

I don't know that this will do what we want, but I think it's worth trying. The possible downside is fields outside the metadata being treated as numbers, with unexpected consequences. We might also hit a problem if the first document with a given field looks like a number... but later documents reveal it to be a string.