### PR TITLE
Add file extension to description

### DIFF
--- a/src/elasticsearch/addl_index_transformations/portal/__init__.py
+++ b/src/elasticsearch/addl_index_transformations/portal/__init__.py
@@ -80,6 +80,14 @@ def transform(doc, batch_id='unspecified'):
     ...            ]
     ...        }
     ...    },
+    ...    'files': [{
+    ...        "description": "OME-TIFF pyramid file",
+    ...        "edam_term": "EDAM_1.24.format_3727",
+    ...        "is_qa_qc": False,
+    ...        "rel_path": "ometiff-pyramids/stitched/expressions/reg1_stitched_expressions.ome.tif",
+    ...        "size": 123456789,
+    ...        "type": "unknown"
+    ...    }],
     ...    'metadata': {
     ...        'metadata': {
     ...            '_random_stuff_that_should_not_be_ui': 'No!',
@@ -117,6 +125,13 @@ def transform(doc, batch_id='unspecified'):
                                                   'grouping_concept_preferred_term': 'Sex',
                                                   'preferred_term': 'Male'}]}},
      'entity_type': 'dataset',
+     'files': [{'description': 'OME-TIFF pyramid file',
+                'edam_term': 'EDAM_1.24.format_3727',
+                'is_qa_qc': False,
+                'mapped_description': 'OME-TIFF pyramid file (TIF file)',
+                'rel_path': 'ometiff-pyramids/stitched/expressions/reg1_stitched_expressions.ome.tif',
+                'size': 123456789,
+                'type': 'unknown'}],
      'group_name': 'EXT - Outside HuBMAP',
      'mapped_consortium': 'Outside HuBMAP',
      'mapped_create_timestamp': '2019-12-04 19:58:29',

--- a/src/elasticsearch/addl_index_transformations/portal/translate.py
+++ b/src/elasticsearch/addl_index_transformations/portal/translate.py
@@ -18,6 +18,7 @@ def _unexpected(s):
 
 def translate(doc):
     _add_metadata_metadata_placeholder(doc)
+    _translate_file_description(doc)
     _translate_status(doc)
     _translate_organ(doc)
     _translate_donor_metadata(doc)
@@ -73,6 +74,34 @@ def _add_metadata_metadata_placeholder(doc):
     '''
     if doc['entity_type'] in ['Donor', 'Sample'] and 'metadata' in doc:
         doc['metadata']['metadata'] = {'has_metadata': True}
+
+
+# File description:
+
+def _translate_file_description(doc):
+    '''
+    >>> doc = {'files': [{
+    ...     "description": "OME-TIFF pyramid file",
+    ...     "edam_term": "EDAM_1.24.format_3727",
+    ...     "is_qa_qc": False,
+    ...     "rel_path": "ometiff-pyramids/stitched/expressions/reg1_stitched_expressions.ome.tif",
+    ...     "size": 123456789,
+    ...     "type": "unknown"
+    ... }]}
+    >>> _translate_file_description(doc)
+    >>> from pprint import pprint
+    >>> pprint(doc)
+    {'files': [{'description': 'OME-TIFF pyramid file',
+                'edam_term': 'EDAM_1.24.format_3727',
+                'is_qa_qc': False,
+                'mapped_description': 'OME-TIFF pyramid file (TIF file)',
+                'rel_path': 'ometiff-pyramids/stitched/expressions/reg1_stitched_expressions.ome.tif',
+                'size': 123456789,
+                'type': 'unknown'}]}
+    '''
+    for file in doc.get('files', []):
+        extension = file['rel_path'].split('.')[-1].upper()
+        file['mapped_description'] = file['description'] + f' ({extension} file)'
 
 
 # Data access level:


### PR DESCRIPTION
For file manifest generation, knowing the type of the file may be important to the user. The same information may be available in multiple formats. (ie, a QA report available as text or pdf or html...)

I believe that adding the file extension to the description was what we settled on, but there are other ways this could be done:
- upper vs lower case?
- leading `.` or no `.`?
- maybe skip this if the extension is already in the description... but the consistency may be a good thing?

Or we could take an entirely different approach...
- Elasticsearch [nested fields](https://www.elastic.co/guide/en/elasticsearch/reference/current/nested.html) work like sub-documents inside the parent document.
- Or (and I don't think this is the direction we're going) there could be a separate ES index just for the files. [Proposal](https://docs.google.com/document/d/1zZaX64Wx_f0j0lQWw4mA7DHpjA5rQ-CKmjIx6k6UpoE/edit).

@tsliaw -- Confirm that the resulting strings satisfy the requirements of the UI you're working on?

cc @mruffalo -- I think you've been providing the descriptions. Mostly just a heads up about how we intend to use the information you provide.
