### PR TITLE
Use default Elasticsearch service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,8 @@ language: python
 python:
   - '3.7'
 cache: pip
-before_install:
-  # From https://docs.travis-ci.com/user/database-setup/#installing-specific-versions-of-elasticsearch
-  # (Version matches that used on AWS.)
-  - curl https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.4.2-amd64.deb -o elasticsearch.deb
-  - sudo dpkg -i --force-confnew elasticsearch.deb
-  - sudo chown -R elasticsearch:elasticsearch /etc/default/elasticsearch
-  - sudo service elasticsearch restart
+services:
+  - elasticsearch
 before_script:
   - sleep 10  # Advised by https://docs.travis-ci.com/user/database-setup/#elasticsearch
 env:


### PR DESCRIPTION
Using specific Elasticsearch install no longer worked, switch to the default service to fix the Travis build.