### PR TITLE
Add codex_cytokit_v1 assay type; change hints in codex_cytokit

### DIFF
--- a/src/search-schema/data/definitions/enums/assay_types.yaml
+++ b/src/search-schema/data/definitions/enums/assay_types.yaml
@@ -49,12 +49,19 @@ CODEX:
     contains-pii: false
     vitessce-hints: []
 
-codex_cytokit:
+codex_cytokit_v1:
     description: CODEX [Cytokit + SPRM]
     alt-names: []
     primary: false
     contains-pii: false
     vitessce-hints: ['codex', 'is_image', 'is_tiled']
+
+codex_cytokit:
+    description: CODEX [Cytokit + SPRM]
+    alt-names: []
+    primary: false
+    contains-pii: false
+    vitessce-hints: ['sprm', 'anndata', 'is_image', 'is_tiled']
 
 DART-FISH:
     description: DART-FISH


### PR DESCRIPTION
This branch:
* creates a new assay type, codex_cytokit_v1, with the vitessce-hints historically associated with codex_cytokit
* updates the vitessce-hints of codex_cytokit to match those of celldive_deepcell
