### PR TITLE
Add validation names as alt names for LC-MS and MS top down & bottom up

### DIFF
--- a/src/search-schema/data/definitions/enums/assay_types.yaml
+++ b/src/search-schema/data/definitions/enums/assay_types.yaml
@@ -478,28 +478,28 @@ MS:
 
 LC-MS_bottom_up:
     description: 'LC-MS Bottom Up'
-    alt-names: []
+    alt-names: ['LC-MS Bottom-Up']
     primary: true
     contains-pii: false
     vitessce-hints: []
 
 MS_bottom_up:
     description: 'MS Bottom Up'
-    alt-names: []
+    alt-names: ['MS Bottom-Up']
     primary: true
     contains-pii: false
     vitessce-hints: []
 
 LC-MS_top_down:
     description: 'LC-MS Top Down'
-    alt-names: []
+    alt-names: ['LC-MS Top-Down']
     primary: true
     contains-pii: false
     vitessce-hints: []
 
 MS_top_down:
     description: 'MS Top Down'
-    alt-names: []
+    alt-names: ['MS Top-Down']
     primary: true
     contains-pii: false
     vitessce-hints: []


### PR DESCRIPTION
This change adds needed alt-names to the assay types LC-MS Top Down, LC-MS Bottom Up, MS Top Down, and MS Bottom-Up