### PR TITLE
Add CODEX2, variant assay type for interim handling of new dir schema

### DIFF
--- a/src/search-schema/data/definitions/enums/assay_types.yaml
+++ b/src/search-schema/data/definitions/enums/assay_types.yaml
@@ -49,6 +49,14 @@ CODEX:
     contains-pii: false
     vitessce-hints: []
 
+# interim solution to handle variant CODEX with new directory schema
+CODEX2:
+    description: CODEX
+    alt-names: []
+    primary: true
+    contains-pii: false
+    vitessce-hints: []
+
 codex_cytokit_v1:
     description: CODEX [Cytokit + SPRM]
     alt-names: []


### PR DESCRIPTION
This PR adds the primary assay type CODEX2.  This assay type is intended to allow interim handling of CODEX data with the new style directory schema, since we have no way to distinguish assays based only on directory schema version number.