### PR TITLE
Give CODEX2 assay type a unique description string

### DIFF
--- a/src/search-schema/data/definitions/enums/assay_types.yaml
+++ b/src/search-schema/data/definitions/enums/assay_types.yaml
@@ -51,7 +51,7 @@ CODEX:
 
 # interim solution to handle variant CODEX with new directory schema
 CODEX2:
-    description: CODEX
+    description: CODEX (CODEX2 assay type)
     alt-names: []
     primary: true
     contains-pii: false


### PR DESCRIPTION
This PR sets a unique 'description' for the assay type CODEX2 in assay_types.yaml .  This is an interim solution.