### PR TITLE
Fixed a bug in hubmap_translator.py generate_doc where, if an entity was

### DIFF
--- a/src/hubmap_translator.py
+++ b/src/hubmap_translator.py
@@ -620,7 +620,11 @@ class Translator(TranslatorInterface):
                 entity['donor'] = donor
 
                 entity['origin_sample'] = copy.copy(entity) if ('specimen_type' in entity) and (entity['specimen_type'].lower() == 'organ') and ('organ' in entity) and (entity['organ'].strip() != '') else None
-                entity['origin_samples'] = copy.copy(entity) if ('specimen_type' in entity) and (entity['specimen_type'].lower() == 'organ') and ('organ' in entity) and (entity['organ'].strip() != '') else None
+
+                if ('specimen_type' in entity) and (entity['specimen_type'].lower() == 'organ') and ('organ' in entity) and (entity['organ'].strip() != ''):
+                    entity['origin_samples'] = [copy.copy(entity)]
+                else:
+                    entity['origin_samples'] = None
 
                 if entity['origin_sample'] is None:
                     try:


### PR DESCRIPTION
Fixed a bug in hubmap_translator.py generate_doc where, if an entity was
its own origin sample, a dictionary is returned rather than a list causing
an error later.