### PR TITLE
Derek furst/expose metadata

### DIFF
--- a/src/hubmap_translator.py
+++ b/src/hubmap_translator.py
@@ -663,7 +663,16 @@ class Translator(TranslatorInterface):
                     if 'ingest_metadata' in entity:
                         ingest_metadata = entity['ingest_metadata']
                         if 'files' in ingest_metadata:
-                            entity['files'] = ingest_metadata['files']
+                            if ingest_metadata['files'].strip() == "":
+                                entity['files'] = []
+                            else:
+                                entity['files'] = ingest_metadata['files']
+                        else:
+                            entity['files'] = []
+                    else:
+                        entity['files'] = []
+
+
 
             self.entity_keys_rename(entity)
 

--- a/src/hubmap_translator.py
+++ b/src/hubmap_translator.py
@@ -660,17 +660,11 @@ class Translator(TranslatorInterface):
                             entity['source_sample'] = {}
 
                     # Move files to the root level if exist
+                    entity['files'] = []
                     if 'ingest_metadata' in entity:
                         ingest_metadata = entity['ingest_metadata']
-                        if 'files' in ingest_metadata:
-                            if ingest_metadata['files'].strip() == "":
-                                entity['files'] = []
-                            else:
-                                entity['files'] = ingest_metadata['files']
-                        else:
-                            entity['files'] = []
-                    else:
-                        entity['files'] = []
+                        if 'files' in ingest_metadata and ((isinstance(ingest_metadata['files'], str) and ingest_metadata['files'].strip() != '') or not isinstance(ingest_metadata['files'], str)):
+                            entity['files'] = ingest_metadata.pop('files')
 
 
 
@@ -689,10 +683,6 @@ class Translator(TranslatorInterface):
                 # Add new property
                 entity['group_name'] = group_dict['displayname']
 
-            # Remove the `files` element from the entity['metadata'] dict
-            # to reduce the doc size to be indexed?
-            if ('metadata' in entity) and ('files' in entity['metadata']):
-                entity['metadata'].pop('files')
 
             # Rename for properties that are objects
             if entity.get('donor', None):


### PR DESCRIPTION
If ingest_metadata or ingest_metadata.files is empty in hubmap_translator.py, `"files": []` is added to the top level "entity"