### PR TITLE
Bump es limit to 6500

### DIFF
--- a/src/hubmap_translation/addl_index_transformations/portal/config.yaml
+++ b/src/hubmap_translation/addl_index_transformations/portal/config.yaml
@@ -1,6 +1,6 @@
 settings:
   index:
-    mapping.total_fields.limit: 6000
+    mapping.total_fields.limit: 6500
     query.default_field: 2048
 
 mappings:

--- a/src/hubmap_translation/search-default-config.yaml
+++ b/src/hubmap_translation/search-default-config.yaml
@@ -1,6 +1,6 @@
 settings:
   index:
-    mapping.total_fields.limit: 6000
+    mapping.total_fields.limit: 6500
     query.default_field: 2048
 
 mappings:


### PR DESCRIPTION
Address reindex error on uuid `252ecf4c2996062c2b06c3c6986b2900`:

```
[2022-07-19 17:34:22] DEBUG in indexer:24: Creating document with uuid: 681801ff07473a0bef08618ecf263339 at index: hm_test_consortium_portal
[2022-07-19 17:34:22] DEBUG in connectionpool:971: Starting new HTTPS connection (1): search-hubmap-dev-test-hfnqv4ylo5ywvc42vwnyptbup4.us-east-1.es.amazonaws.com:443
[2022-07-19 17:34:22] DEBUG in connectionpool:452: [https://search-hubmap-dev-test-hfnqv4ylo5ywvc42vwnyptbup4.us-east-1.es.amazonaws.com:443](https://search-hubmap-dev-test-hfnqv4ylo5ywvc42vwnyptbup4.us-east-1.es.amazonaws.com/) "PUT /hm_test_consortium_portal/_doc/681801ff07473a0bef08618ecf263339 HTTP/1.1" 400 229
[2022-07-19 17:34:22] ERROR in es_writer:56: Failed to write doc of uuid: 681801ff07473a0bef08618ecf263339 to index: hm_test_consortium_portal
[2022-07-19 17:34:22] ERROR in es_writer:57: Error Message: {"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"Limit of total fields [6000] has been exceeded"}],"type":"illegal_argument_exception","reason":"Limit of total fields [6000] has been exceeded"},"status":400}
[2022-07-19 17:34:22] INFO in hubmap_translator:213: ################reindex() DONE######################
```