### PR TITLE
Fix shallow copy

### DIFF
--- a/src/hubmap_translator.py
+++ b/src/hubmap_translator.py
@@ -26,6 +26,7 @@ logging.basicConfig(format='[%(asctime)s] %(levelname)s in %(module)s: %(message
                     datefmt='%Y-%m-%d %H:%M:%S')
 logger = logging.getLogger(__name__)
 
+# This list contains fields that are added to the top-level at index runtime
 entity_properties_list = [
     'metadata',
     'donor',
@@ -40,6 +41,7 @@ entity_properties_list = [
     'immediate_descendants',
     'datasets'
 ]
+
 entity_types = ['Upload', 'Donor', 'Sample', 'Dataset']
 
 
@@ -451,11 +453,13 @@ class Translator(TranslatorInterface):
             # Log the full stack trace, prepend a line with our message
             logger.exception(msg)
 
+
     # The added fields specified in `entity_properties_list` should not be added
     # to themselves as sub fields
-    def exclude_added_top_level_properties(self, entity_dict):
+    # The `except_properties_list` is a subset of entity_properties_list
+    def exclude_added_top_level_properties(self, entity_dict, except_properties_list = []):
         for prop in entity_properties_list:
-            if prop in entity_dict:
+            if (prop in entity_dict) and (prop not in except_properties_list):
                  entity_dict.pop(prop)
 
 
@@ -468,6 +472,7 @@ class Translator(TranslatorInterface):
                 dataset = self.call_entity_api(dataset['uuid'], 'entities')
 
                 dataset_doc = self.generate_doc(dataset, 'dict')
+
                 # dataset_doc.pop('ancestors')
                 # dataset_doc.pop('ancestor_ids')
                 # dataset_doc.pop('descendants')
@@ -478,7 +483,10 @@ class Translator(TranslatorInterface):
                 # dataset_doc.pop('origin_sample')
                 # dataset_doc.pop('source_sample')
 
-                self.exclude_added_top_level_properties(dataset_doc)
+                # This function call is equvalant to the above lines commented out
+                # We probably don't need to except 'datasets' property because 
+                # Dataset has no such property ever defined in entity schema yaml? - 7/22/2022 Zhou
+                self.exclude_added_top_level_properties(dataset_doc, except_properties = ['metadata', 'files', 'datasets'])
 
                 datasets.append(dataset_doc)
 

--- a/src/hubmap_translator.py
+++ b/src/hubmap_translator.py
@@ -669,7 +669,7 @@ class Translator(TranslatorInterface):
                             entity['source_sample'] = {}
 
                     # Remove those added fields specified in `entity_properties_list` from origin_sample and source_sample
-                    self.exclude_added_top_level_properties(entity['origin_sample'])
+                    self.exclude_added_top_level_properties(entity['source_sample'])
 
                     # Move files to the root level if exist
                     if 'ingest_metadata' in entity:

--- a/src/hubmap_translator.py
+++ b/src/hubmap_translator.py
@@ -451,6 +451,13 @@ class Translator(TranslatorInterface):
             # Log the full stack trace, prepend a line with our message
             logger.exception(msg)
 
+    # The added fields specified in `entity_properties_list` should not be added
+    # to themselves as sub fields
+    def exclude_added_top_level_properties(self, entity_dict):
+        for prop in entity_properties_list:
+            if prop in entity_dict:
+                 entity_dict.pop(prop)
+
 
     # Used for Upload and Collection index
     def add_datasets_to_entity(self, entity):
@@ -461,15 +468,17 @@ class Translator(TranslatorInterface):
                 dataset = self.call_entity_api(dataset['uuid'], 'entities')
 
                 dataset_doc = self.generate_doc(dataset, 'dict')
-                dataset_doc.pop('ancestors')
-                dataset_doc.pop('ancestor_ids')
-                dataset_doc.pop('descendants')
-                dataset_doc.pop('descendant_ids')
-                dataset_doc.pop('immediate_descendants')
-                dataset_doc.pop('immediate_ancestors')
-                dataset_doc.pop('donor')
-                dataset_doc.pop('origin_sample')
-                dataset_doc.pop('source_sample')
+                # dataset_doc.pop('ancestors')
+                # dataset_doc.pop('ancestor_ids')
+                # dataset_doc.pop('descendants')
+                # dataset_doc.pop('descendant_ids')
+                # dataset_doc.pop('immediate_descendants')
+                # dataset_doc.pop('immediate_ancestors')
+                # dataset_doc.pop('donor')
+                # dataset_doc.pop('origin_sample')
+                # dataset_doc.pop('source_sample')
+
+                self.exclude_added_top_level_properties(dataset_doc)
 
                 datasets.append(dataset_doc)
 
@@ -637,6 +646,9 @@ class Translator(TranslatorInterface):
                     except StopIteration:
                         entity['origin_sample'] = {}
 
+                # Remove those added fields specified in `entity_properties_list` from origin_sample and source_sample
+                self.exclude_added_top_level_properties(entity['origin_sample'])
+
                 # Trying to understand here!!!
                 if entity['entity_type'] == 'Dataset':
                     entity['source_sample'] = None
@@ -655,6 +667,9 @@ class Translator(TranslatorInterface):
                             e = parents[0]
                         except IndexError:
                             entity['source_sample'] = {}
+
+                    # Remove those added fields specified in `entity_properties_list` from origin_sample and source_sample
+                    self.exclude_added_top_level_properties(entity['origin_sample'])
 
                     # Move files to the root level if exist
                     if 'ingest_metadata' in entity:

--- a/src/hubmap_translator.py
+++ b/src/hubmap_translator.py
@@ -655,7 +655,7 @@ class Translator(TranslatorInterface):
                         entity['origin_sample'] = {}
 
                 # Remove those added fields specified in `entity_properties_list` from origin_sample and source_sample
-                self.exclude_added_top_level_properties(entity['origin_sample'])
+                self.exclude_added_top_level_properties(entity['origin_sample'], except_properties_list = ['metadata'])
 
                 # Trying to understand here!!!
                 if entity['entity_type'] == 'Dataset':
@@ -677,7 +677,7 @@ class Translator(TranslatorInterface):
                             entity['source_sample'] = {}
 
                     # Remove those added fields specified in `entity_properties_list` from origin_sample and source_sample
-                    self.exclude_added_top_level_properties(entity['source_sample'])
+                    self.exclude_added_top_level_properties(entity['source_sample'], except_properties_list = ['metadata'])
 
                     # Move files to the root level if exist
                     if 'ingest_metadata' in entity:

--- a/src/hubmap_translator.py
+++ b/src/hubmap_translator.py
@@ -483,10 +483,10 @@ class Translator(TranslatorInterface):
                 # dataset_doc.pop('origin_sample')
                 # dataset_doc.pop('source_sample')
 
-                # This function call is equvalant to the above lines commented out
+                # This function call is equivalent to the above lines commented out
                 # We probably don't need to except 'datasets' property because 
                 # Dataset has no such property ever defined in entity schema yaml? - 7/22/2022 Zhou
-                self.exclude_added_top_level_properties(dataset_doc, except_properties = ['metadata', 'files', 'datasets'])
+                self.exclude_added_top_level_properties(dataset_doc, except_properties_list = ['metadata', 'files', 'datasets'])
 
                 datasets.append(dataset_doc)
 

--- a/src/hubmap_translator.py
+++ b/src/hubmap_translator.py
@@ -407,9 +407,6 @@ class Translator(TranslatorInterface):
         return headers_dict
 
     def call_indexer(self, entity, reindex=False, document=None, target_index=None):
-        # Make a deepcopy
-        org_node = copy.deepcopy(entity)
-
         try:
             if document is None:
                 document = self.generate_doc(entity, 'json')
@@ -429,7 +426,7 @@ class Translator(TranslatorInterface):
                     # check to see if the index has a transformer, default to None if not found
                     transformer = self.TRANSFORMERS.get(index, None)
 
-                    if self.is_public(org_node):
+                    if self.is_public(entity):
                         public_doc = self.generate_public_doc(entity)
 
                         if transformer is not None:
@@ -450,7 +447,7 @@ class Translator(TranslatorInterface):
 
                     self.indexer.index(entity['uuid'], target_doc, private_index, reindex)
         except Exception:
-            msg = f"Exception encountered during executing HuBMAPTranslator call_indexer() for uuid: {org_node['uuid']}, entity_type: {org_node['entity_type']}"
+            msg = f"Exception encountered during executing HuBMAPTranslator call_indexer() for uuid: {entity['uuid']}, entity_type: {entity['entity_type']}"
             # Log the full stack trace, prepend a line with our message
             logger.exception(msg)
 
@@ -587,8 +584,7 @@ class Translator(TranslatorInterface):
                 donor = None
                 for a in ancestors:
                     if a['entity_type'] == 'Donor':
-                        # Make a deepcopy
-                        donor = copy.deepcopy(a)
+                        donor = copy.copy(a)
                         break
 
                 # Get back a list of descendant uuids first
@@ -629,15 +625,13 @@ class Translator(TranslatorInterface):
                 # Add new properties
                 entity['donor'] = donor
 
-                # Make a deepcopy
-                entity['origin_sample'] = copy.deepcopy(entity) if ('specimen_type' in entity) and (
+                entity['origin_sample'] = copy.copy(entity) if ('specimen_type' in entity) and (
                         entity['specimen_type'].lower() == 'organ') and ('organ' in entity) and (
                                                                        entity['organ'].strip() != '') else None
                 if entity['origin_sample'] is None:
                     try:
                         # The origin_sample is the ancestor which `specimen_type` is "organ" and the `organ` code is set
-                        # Make a deepcopy
-                        entity['origin_sample'] = copy.deepcopy(next(a for a in ancestors if ('specimen_type' in a) and (
+                        entity['origin_sample'] = copy.copy(next(a for a in ancestors if ('specimen_type' in a) and (
                                 a['specimen_type'].lower() == 'organ') and ('organ' in a) and (
                                                                          a['organ'].strip() != '')))
                     except StopIteration:

--- a/src/hubmap_translator.py
+++ b/src/hubmap_translator.py
@@ -42,7 +42,8 @@ entity_properties_list = [
     'datasets'
 ]
 
-entity_types = ['Upload', 'Donor', 'Sample', 'Dataset']
+# Entity types that will have `display_subtype` generated ar index time
+entity_types_with_display_subtype = ['Upload', 'Donor', 'Sample', 'Dataset']
 
 
 class Translator(TranslatorInterface):
@@ -533,7 +534,7 @@ class Translator(TranslatorInterface):
         entity['index_version'] = self.index_version
 
         # Add display_subtype
-        if entity['entity_type'] in entity_types:
+        if entity['entity_type'] in entity_types_with_display_subtype:
             entity['display_subtype'] = self.generate_display_subtype(entity)
 
     # For Upload, Dataset, Donor and Sample objects:


### PR DESCRIPTION
This PR fixes the ES fields explosion issue introduced by using shallow copy as well as removing unwanted fields from the current PROD.

TODO: 
- Full reindex on STAGE 
- Find out the total number of fields by `GET hm_stage_consortium_portal/_field_caps?fields=*` and update the settings in yaml with a proper limit.
- Will also need to verify this on TEST