### PR TITLE
Yuanzhou/fix nested files with empty string

### DIFF
--- a/src/hubmap_translator.py
+++ b/src/hubmap_translator.py
@@ -763,6 +763,7 @@ class Translator(TranslatorInterface):
         if ('ingest_metadata' in dataset_dict) and ('files' in dataset_dict['ingest_metadata']):
             if isinstance(dataset_dict['ingest_metadata']['files'], str) and (dataset_dict['ingest_metadata']['files'].strip() == ''):
                 del dataset_dict['ingest_metadata']['files']
+                logger.info(f"Removed ['ingest_metadata']['files'] due to empty string value, for Dataset {dataset_dict['uuid']}")
 
         # Remove any `ingest_metadata.metadata.*` sub fields if the value is empty string or just whitespace 
         # to to avoid dynamic mapping conflict

--- a/src/hubmap_translator.py
+++ b/src/hubmap_translator.py
@@ -681,10 +681,13 @@ class Translator(TranslatorInterface):
                     self.exclude_added_top_level_properties(entity['source_sample'], except_properties_list = ['metadata'])
 
                     # Move files to the root level if exist
+                    entity['files'] = []
                     if 'ingest_metadata' in entity:
                         ingest_metadata = entity['ingest_metadata']
                         if 'files' in ingest_metadata:
-                            entity['files'] = ingest_metadata['files']
+                            if ((isinstance(ingest_metadata['files'], str) and ingest_metadata['files'].strip() != '') or not isinstance(ingest_metadata['files'], str)):
+                                entity['files'] = ingest_metadata['files']
+                            entity['ingest_metadata'].pop('files')
 
             self.entity_keys_rename(entity)
 
@@ -700,11 +703,6 @@ class Translator(TranslatorInterface):
 
                 # Add new property
                 entity['group_name'] = group_dict['displayname']
-
-            # Remove the `files` element from the entity['metadata'] dict
-            # to reduce the doc size to be indexed?
-            if ('metadata' in entity) and ('files' in entity['metadata']):
-                entity['metadata'].pop('files')
 
             # Rename for properties that are objects
             if entity.get('donor', None):

--- a/src/hubmap_translator.py
+++ b/src/hubmap_translator.py
@@ -28,7 +28,6 @@ logger = logging.getLogger(__name__)
 
 # This list contains fields that are added to the top-level at index runtime
 entity_properties_list = [
-    'metadata',
     'donor',
     'origin_sample',
     'source_sample',
@@ -36,10 +35,10 @@ entity_properties_list = [
     'descendant_ids',
     'ancestors',
     'descendants',
+    # This 'files' field is either empty list [] or the files info list copied from 'Dataset.ingest_metadata.files'
     'files',
     'immediate_ancestors',
-    'immediate_descendants',
-    'datasets'
+    'immediate_descendants'
 ]
 
 # Entity types that will have `display_subtype` generated ar index time
@@ -178,6 +177,8 @@ class Translator(TranslatorInterface):
     def translate(self, entity_id):
         try:
             # Retrieve the entity details
+            # This returned entity dict (if Dataset) has removed ingest_metadata.files and 
+            # ingest_metadata.metadata sub fields with empty string values when call_entity_api() gets called
             entity = self.call_entity_api(entity_id, 'entities')
 
             # Check if entity is empty
@@ -409,6 +410,8 @@ class Translator(TranslatorInterface):
 
         return headers_dict
 
+    # Note: this entity dict input (if Dataset) has already removed ingest_metadata.files and 
+    # ingest_metadata.metadata sub fields with empty string values from previous call
     def call_indexer(self, entity, reindex=False, document=None, target_index=None):
         try:
             if document is None:
@@ -471,24 +474,8 @@ class Translator(TranslatorInterface):
             for dataset in entity['datasets']:
                 # Retrieve the entity details
                 dataset = self.call_entity_api(dataset['uuid'], 'entities')
-
                 dataset_doc = self.generate_doc(dataset, 'dict')
-
-                # dataset_doc.pop('ancestors')
-                # dataset_doc.pop('ancestor_ids')
-                # dataset_doc.pop('descendants')
-                # dataset_doc.pop('descendant_ids')
-                # dataset_doc.pop('immediate_descendants')
-                # dataset_doc.pop('immediate_ancestors')
-                # dataset_doc.pop('donor')
-                # dataset_doc.pop('origin_sample')
-                # dataset_doc.pop('source_sample')
-
-                # This function call is equivalent to the above lines commented out
-                # We probably don't need to except 'datasets' property because 
-                # Dataset has no such property ever defined in entity schema yaml? - 7/22/2022 Zhou
-                self.exclude_added_top_level_properties(dataset_doc, except_properties_list = ['metadata', 'files', 'datasets'])
-
+                self.exclude_added_top_level_properties(dataset_doc)
                 datasets.append(dataset_doc)
 
         entity['datasets'] = datasets
@@ -577,6 +564,8 @@ class Translator(TranslatorInterface):
 
         return display_subtype
 
+    # Note: this entity dict input (if Dataset) has already removed ingest_metadata.files and 
+    # ingest_metadata.metadata sub fields with empty string values from previous call
     def generate_doc(self, entity, return_type):
         try:
             entity_id = entity['uuid']
@@ -596,12 +585,6 @@ class Translator(TranslatorInterface):
                     # No need to call self.exclude_dataset_ingest_metadata_empty_fields() here because
                     # self.call_entity_api() already handled that
                     ancestor_dict = self.call_entity_api(ancestor_uuid, 'entities')
-
-                    # Only applies when this ancestor entity is a Dataset
-                    # Use case 2: call this method to remove the `ingest_metadata.files` only when its value is empty string
-                    # to avoid mapping conflict by setting the `only_on_empty_string` parameter to True
-                    self.remove_dataset_metadata_files(ancestor_dict, only_on_empty_string = True)
-
                     ancestors.append(ancestor_dict)
 
                 # Find the Donor
@@ -617,37 +600,21 @@ class Translator(TranslatorInterface):
                     # No need to call self.exclude_dataset_ingest_metadata_empty_fields() here because
                     # self.call_entity_api() already handled that
                     descendant_dict = self.call_entity_api(descendant_uuid, 'entities')
-
-                    # Only applies when this ancestor entity is a Dataset
-                    # Use case 2: call this method to remove the `ingest_metadata.files` only when its value is empty string
-                    # to avoid mapping conflict by setting the `only_on_empty_string` parameter to True
-                    self.remove_dataset_metadata_files(descendant_dict, only_on_empty_string = True)
-
                     descendants.append(descendant_dict)
 
                 # Calls to /parents/<id> and /children/<id> have no performance/timeout concerns
                 immediate_ancestors_list = self.call_entity_api(entity_id, 'parents')
                 for immediate_ancestor_dict in immediate_ancestors_list:
-                    # Only applies when this ancestor entity is a Dataset
-                    # Use case 2: call this method to remove the `ingest_metadata.files` only when its value is empty string
-                    # to avoid mapping conflict by setting the `only_on_empty_string` parameter to True
-                    self.remove_dataset_metadata_files(immediate_ancestor_dict, only_on_empty_string = True)
-
                     # We need to call self.exclude_dataset_ingest_metadata_empty_fields() here because
                     # self.call_entity_api() above returned a list of immediate ancestor dicts instead of uuids
-                    # without excluding any Dataset.ingest_metadata.metadata sub fields with empty string values
+                    # without excluding any Dataset.ingest_metadata.files and Dataset.ingest_metadata.metadata sub fields with empty string values
                     immediate_ancestors.append(self.exclude_dataset_ingest_metadata_empty_fields(immediate_ancestor_dict))
 
                 immediate_descendants_list = self.call_entity_api(entity_id, 'children')
                 for immediate_descendant_dict in immediate_descendants_list:
-                    # Only applies when this ancestor entity is a Dataset
-                    # Use case 2: call this method to remove the `ingest_metadata.files` only when its value is empty string
-                    # to avoid mapping conflict by setting the `only_on_empty_string` parameter to True
-                    self.remove_dataset_metadata_files(immediate_descendant_dict, only_on_empty_string = True)
-
                     # We need to call self.exclude_dataset_ingest_metadata_empty_fields() here because
                     # self.call_entity_api() above returned a list of immediate descendant dicts instead of uuids
-                    # without excluding any Dataset.ingest_metadata.metadata sub fields with empty string values
+                    # without excluding any Dataset.ingest_metadata.files and Dataset.ingest_metadata.metadata sub fields with empty string values
                     immediate_descendants.append(self.exclude_dataset_ingest_metadata_empty_fields(immediate_descendant_dict))
                 
                 # Add new properties to entity
@@ -678,7 +645,7 @@ class Translator(TranslatorInterface):
                         entity['origin_sample'] = {}
 
                 # Remove those added fields specified in `entity_properties_list` from origin_sample and source_sample
-                self.exclude_added_top_level_properties(entity['origin_sample'], except_properties_list = ['metadata'])
+                self.exclude_added_top_level_properties(entity['origin_sample'])
 
                 # Trying to understand here!!!
                 if entity['entity_type'] == 'Dataset':
@@ -700,7 +667,7 @@ class Translator(TranslatorInterface):
                             entity['source_sample'] = {}
 
                     # Remove those added fields specified in `entity_properties_list` from origin_sample and source_sample
-                    self.exclude_added_top_level_properties(entity['source_sample'], except_properties_list = ['metadata'])
+                    self.exclude_added_top_level_properties(entity['source_sample'])
 
                     # Move files to the root level if exist
                     entity['files'] = []
@@ -710,9 +677,8 @@ class Translator(TranslatorInterface):
                             if ((isinstance(ingest_metadata['files'], str) and ingest_metadata['files'].strip() != '') or not isinstance(ingest_metadata['files'], str)):
                                 entity['files'] = ingest_metadata['files']
 
-                            # Use case 1: always remove the `files` property after copying the original files data to top level
-                            # Regardless if its value is an actual list of files info or empty string
-                            self.remove_dataset_metadata_files(entity)
+                            # Always remove the `ingest_metadata.files` property after copying the original files data to top level
+                            entity['ingest_metadata'].pop('files')
 
             self.entity_keys_rename(entity)
 
@@ -762,22 +728,6 @@ class Translator(TranslatorInterface):
             logger.exception(msg)
 
 
-    # Remove the `ingest_metadata.files` field from a given dataset dict
-    # Need to perform a check when `only_on_empty_string` parameter is set to True, otherwise just remove
-    # Use case 1: call this method after copying the files data to the top level entity.files field
-    # Use case 2: call this method to remove the `ingest_metadata.files` only when its value is empty string
-    # to avoid mapping conflict by setting the `only_on_empty_string` parameter to True
-    def remove_dataset_metadata_files(self, dataset_dict, only_on_empty_string = False):
-        if ('ingest_metadata' in dataset_dict) and ('files' in dataset_dict['ingest_metadata']):
-            if only_on_empty_string:
-                if isinstance(dataset_dict['ingest_metadata']['files'], str) and (dataset_dict['ingest_metadata']['files'].strip() == ''):
-                    dataset_dict['ingest_metadata'].pop('files')
-                    logger.info(f"Removed ingest_medata.files with 'only_on_empty_string = True' for dataset uuid {dataset_dict['uuid']}")
-            else:
-                dataset_dict['ingest_metadata'].pop('files')
-                logger.info(f"Removed ingest_medata.files with 'only_on_empty_string = False' for dataset uuid {dataset_dict['uuid']}")
-
-
     def generate_public_doc(self, entity):
         # Only Dataset has this 'next_revision_uuid' property
         property_key = 'next_revision_uuid'
@@ -805,9 +755,17 @@ class Translator(TranslatorInterface):
         entity['immediate_descendants'] = list(filter(self.is_public, entity['immediate_descendants']))
         return json.dumps(entity)
 
-    # Remove any Dataset.ingest_metadata.metadata sub fields if the value is empty string or just whitespace 
-    # to address the Elasticsearch index error due to inconsistent data types - 7/13/2022 Max & Zhou
+    # Remove unwanted empty string fields
+    # - `ingest_metadata.files`
+    # - `ingest_metadata.metadata.*` sub fields
     def exclude_dataset_ingest_metadata_empty_fields(self, dataset_dict):
+        # Remove the `ingest_metadata.files` only when its value is empty string to avoid dynamic mapping conflict
+        if ('ingest_metadata' in dataset_dict) and ('files' in dataset_dict['ingest_metadata']):
+            if isinstance(dataset_dict['ingest_metadata']['files'], str) and (dataset_dict['ingest_metadata']['files'].strip() == ''):
+                del dataset_dict['ingest_metadata']['files']
+
+        # Remove any `ingest_metadata.metadata.*` sub fields if the value is empty string or just whitespace 
+        # to to avoid dynamic mapping conflict
         if ('ingest_metadata' in dataset_dict) and ('metadata' in dataset_dict['ingest_metadata']):
             for key in list(dataset_dict['ingest_metadata']['metadata']):
                 if isinstance(dataset_dict['ingest_metadata']['metadata'][key], str):
@@ -844,7 +802,7 @@ class Translator(TranslatorInterface):
                 logger.error(msg)
                 sys.exit(msg)
 
-        # Remove any Dataset.ingest_metadata.metadata sub fields if the value is empty string or just whitespace 
+        # Remove ingest_metadata.files and any Dataset.ingest_metadata.metadata sub fields if the value is empty string or just whitespace 
         # to address the Elasticsearch index error due to inconsistent data types
         # If entity is not Dataset, no change - 7/13/2022 Max & Zhou
         entity_dict = self.exclude_dataset_ingest_metadata_empty_fields(response.json())

--- a/src/hubmap_translator.py
+++ b/src/hubmap_translator.py
@@ -37,6 +37,7 @@ entity_properties_list = [
     'descendants',
     # This 'files' field is either empty list [] or the files info list copied from 'Dataset.ingest_metadata.files'
     'files',
+    'datasets',
     'immediate_ancestors',
     'immediate_descendants'
 ]
@@ -475,7 +476,7 @@ class Translator(TranslatorInterface):
                 # Retrieve the entity details
                 dataset = self.call_entity_api(dataset['uuid'], 'entities')
                 dataset_doc = self.generate_doc(dataset, 'dict')
-                self.exclude_added_top_level_properties(dataset_doc)
+                self.exclude_added_top_level_properties(dataset_doc, except_properties_list = ['files', 'datasets'])
                 datasets.append(dataset_doc)
 
         entity['datasets'] = datasets


### PR DESCRIPTION
To replace the PR #553 since this branch is based off `Derek-Furst/fix-ingest-metadata` with further fixes to the issue described https://github.com/hubmapconsortium/search-api/issues/531#issuecomment-1194102558

- Removed `metadata` from the addon properties list
- Use empty list/array as the default top-level `files` value if no actual data from `ingest_metadata.files`
- Exclude `ingest_metadata.files` with empty string value