### PR TITLE
Mccalluc/combine requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ services:
 before_script:
   - sleep 10  # Advised by https://docs.travis-ci.com/user/database-setup/#elasticsearch
 install:
-  - pip install -r src/search-adaptor/src/requirements.txt
   - pip install -r src/requirements.txt
   - pip install -r src/requirements-dev.txt
 script:

--- a/docker/search-api/Dockerfile
+++ b/docker/search-api/Dockerfile
@@ -40,7 +40,7 @@ RUN yum install -y yum-utils && \
     rm /etc/nginx/conf.d/default.conf && \
     mv nginx/nginx.conf /etc/nginx/nginx.conf && \
     rm -rf nginx && \
-    pip install -r src/search-adaptor/src/requirements.txt -r src/requirements.txt && \
+    pip install -r src/requirements.txt && \
     chmod +x start.sh && \
     yum clean all
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -12,4 +12,4 @@ PyYAML==5.4.1
 # git+https://github.com/hubmapconsortium/commons.git@${COMMONS_BRANCH}#egg=hubmap-commons
 hubmap-commons==2.0.15
 
--r src/search-adaptor/src/requirements.txt
+-r search-adaptor/src/requirements.txt

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -11,3 +11,5 @@ PyYAML==5.4.1
 # Default is master branch specified in search-api's docker-compose.development.yml if not set
 # git+https://github.com/hubmapconsortium/commons.git@${COMMONS_BRANCH}#egg=hubmap-commons
 hubmap-commons==2.0.15
+
+-r src/search-adaptor/src/requirements.txt


### PR DESCRIPTION
`requirements.txt` can use `-r` internally: This lets us specify the transitive requirements in one place, rather than repeating ourselves. It also insures that there aren't dependency conflicts: Right now the dependency versions aren't actually consistent, and the state of the system relies on the order of installation (fragile) rather than pip's dependency resolution (robust). 
```
$ grep Flask src/requirements.txt | grep -v '#'
Flask==2.1.3
```
conflicts with:
```
grep Flask src/search-adaptor/src/requirements.txt | grep -v '#'
Flask==1.1.2
```
but note that:
```
$ cd src/search-adaptor/; git checkout main; cd -
$ grep Flask src/search-adaptor/src/requirements.txt | grep -v '#'
Flask==2.1.3
```

This PR updates search-adaptor to the current version on `main` to resolve this conflict, but you might want something else.

Suggestions:
- libraries (like search-adaptor) should specify ranges on their dependencies so that when they are used with other libraries the risk of incompatible requirements is minimized.
- applications (like search-api) should record the exact set of requirements that are known to work. There are a number of different solutions for this in the python world, including pip freeze, Pipfile, and requirements.in.