### PR TITLE
John conroy/map sample category

### DIFF
--- a/src/hubmap_translation/addl_index_transformations/portal/__init__.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/__init__.py
@@ -112,6 +112,7 @@ def transform(doc, batch_id='unspecified'):
      'ancestor_counts': {'entity_type': {}},
      'ancestor_ids': ['1234', '5678'],
      'ancestors': [{'created_by_user_displayname': 'Daniel Cotter',
+                    'mapped_sample_category': 'Section',
                     'sample_category': 'section'}],
      'create_timestamp': 1575489509656,
      'data_access_level': 'consortium',

--- a/src/hubmap_translation/addl_index_transformations/portal/add_counts.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/add_counts.py
@@ -26,7 +26,7 @@ def add_counts(doc):
     ...    'ancestors': [],
     ...    'descendants': [{
     ...        'entity_type': 'Sample',
-    ...        'mapped_specimen_type': 'Fresh Frozen Tissue Section',
+    ...        'mapped_sample_category': 'Block',
     ...        'mapped_organ': 'Lymph Node',
     ...        'mapped_data_types': ['Autofluorescence Microscopy']
     ...    }]
@@ -36,7 +36,7 @@ def add_counts(doc):
     {'entity_type': {'Sample': 1},
      'mapped_data_types': {'Autofluorescence Microscopy': 1},
      'mapped_organ': {'Lymph Node': 1},
-     'mapped_specimen_type': {'Fresh Frozen Tissue Section': 1}}
+     'mapped_sample_category': {'Block': 1}}
 
     '''
     # Collections do not have ancestors or descendants.
@@ -47,7 +47,7 @@ def add_counts(doc):
     if 'descendants' in doc:
         doc['descendant_counts'] = {k: v for k, v in {
             'entity_type': _count_field(doc['descendants'], 'entity_type'),
-            'mapped_specimen_type': _count_field(doc['descendants'], 'mapped_specimen_type'),
+            'mapped_sample_category': _count_field(doc['descendants'], 'mapped_sample_category'),
             'mapped_organ': _count_field(doc['descendants'], 'mapped_organ'),
             'mapped_data_types': _count_array_field(doc['descendants'], 'mapped_data_types'),
         }.items() if v}

--- a/src/hubmap_translation/addl_index_transformations/portal/translate.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/translate.py
@@ -33,6 +33,7 @@ def translate(doc):
     # Remove mapped_specimen_type translation due to new filed sample_category added 12/20/2022 - Zhou
     # _translate_specimen_type(doc)
 
+    _translate_sample_category(doc)
     _translate_data_type(doc)
     _translate_timestamp(doc)
     _translate_access_level(doc)
@@ -278,6 +279,34 @@ _organ_dict = {
 #     k: v['description']
 #     for k, v in _enums['tissue_sample_types'].items()
 # }
+
+
+# Sample category:
+
+def _translate_sample_category(doc):
+    '''
+    >>> doc = {'sample_category': 'block'}
+    >>> _translate_sample_category(doc); doc
+    {'sample_category': 'block', 'mapped_sample_category': 'Block'}
+
+    >>> doc = {'sample_category': 'xyz'}
+    >>> _translate_sample_category(doc); doc
+    {'sample_category': 'xyz', 'mapped_sample_category': 'No translation for "xyz"'}
+
+    '''
+    _map(doc, 'sample_category', _sample_categories_map)
+
+
+def _sample_categories_map(k):
+    if k not in _sample_categories_dict:
+        return _unexpected(k)
+    return _sample_categories_dict[k]
+
+
+_sample_categories_dict = {
+    k: v['description']
+    for k, v in _enums['tissue_sample_types'].items()
+}
 
 
 # Assay type:

--- a/src/hubmap_translation/indexer_base.py
+++ b/src/hubmap_translation/indexer_base.py
@@ -445,10 +445,7 @@ class Indexer:
                     else:
                         logger.error(f"Missing missing organ when sample_category is set of Sample with uuid: {entity['uuid']}")
                 else:
-                    # block/section/suspension not defined in https://github.com/hubmapconsortium/search-api/blob/main/src/search-schema/data/definitions/enums/tissue_sample_types.yaml
-                    # We just return the capitalized value 12/20/2022
-                    # display_subtype = self.get_tissue_sample_description(entity['sample_category'])
-                    display_subtype = entity['sample_category'].capitalize()
+                    display_subtype = self.get_tissue_sample_description(entity['sample_category'])
             else:
                 logger.error(f"Missing sample_category of Sample with uuid: {entity['uuid']}")
         elif entity_type == 'Dataset':

--- a/src/hubmap_translator.py
+++ b/src/hubmap_translator.py
@@ -593,10 +593,7 @@ class Translator(TranslatorInterface):
                         logger.error(
                             f"Missing missing organ when sample_category is set of Sample with uuid: {entity['uuid']}")
                 else:
-                    # block/section/suspension not defined in https://github.com/hubmapconsortium/search-api/blob/main/src/search-schema/data/definitions/enums/tissue_sample_types.yaml
-                    # We just return the capitalized value 12/20/2022
-                    # display_subtype = get_type_description(entity['sample_category'], 'tissue_sample_types')
-                    display_subtype = entity['sample_category'].capitalize()
+                    display_subtype = get_type_description(entity['sample_category'], 'tissue_sample_types')
             else:
                 logger.error(f"Missing sample_category of Sample with uuid: {entity['uuid']}")
         elif entity_type == 'Dataset':

--- a/src/search-schema/data/definitions/enums/tissue_sample_types.yaml
+++ b/src/search-schema/data/definitions/enums/tissue_sample_types.yaml
@@ -2,6 +2,8 @@ atacseq:
   description: ATACseq
 biopsy:
   description: Biopsy
+block:
+  description: Block
 blood:
   description: Blood
 cell_lysate:
@@ -72,6 +74,8 @@ scatacseq:
   description: scATACseq
 scrnaseq:
   description: scRNAseq
+section:
+  description: Section
 segment:
   description: Segment
 seqfish:
@@ -86,6 +90,8 @@ snatacseq:
   description: snATACseq
 snrnaseq:
   description: snRNAseq
+suspension:
+  description: Suspension
 tissue_lysate:
   description: Tissue lysate
 wgs:


### PR DESCRIPTION
I manually updated the enums in `src/search-schema/data/definitions/enums/tissue_sample_types.yaml` to include the missing mappings for `sample_category` and added similar mapping logic previously used for `specimen_type` for `sample_category`. In this case it only capitalizes the strings.

I'm less sure of the impact on the changes in `src/hubmap_translation/indexer_base.py` and `src/hubmap_translator.py`.