### PR TITLE
John conroy/add origin samples organs

### DIFF
--- a/src/hubmap_translation/addl_index_transformations/portal/tests/fixtures/input-doc.json
+++ b/src/hubmap_translation/addl_index_transformations/portal/tests/fixtures/input-doc.json
@@ -4,6 +4,25 @@
     "origin_sample": {
         "organ": "LY"
     },
+    "origin_samples": [
+        {
+            "organ": "LY"
+        }, 
+        {
+            "organ": "SI"
+        }
+    ],
+    "source_sample": {
+        "organ": "LY"
+    },
+    "source_samples": [
+        {
+            "organ": "LY"
+        }, 
+        {
+            "organ": "SI"
+        }
+    ],
     "create_timestamp": 1575489509656,
     "ancestor_ids": ["1234", "5678"],
     "ancestors": [{

--- a/src/hubmap_translation/addl_index_transformations/portal/tests/fixtures/input-doc.json
+++ b/src/hubmap_translation/addl_index_transformations/portal/tests/fixtures/input-doc.json
@@ -12,9 +12,11 @@
             "organ": "SI"
         }
     ],
-    "source_sample": {
-        "organ": "LY"
-    },
+    "source_sample": [
+        {
+            "organ": "LY"
+        }
+    ],
     "source_samples": [
         {
             "organ": "LY"

--- a/src/hubmap_translation/addl_index_transformations/portal/translate.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/translate.py
@@ -55,8 +55,14 @@ def _map(doc, key, map):
         _map(doc['donor'], key, map)
     if 'origin_sample' in doc:
         _map(doc['origin_sample'], key, map)
+    if 'origin_samples' in doc:
+        for sample in doc['origin_samples']:
+            _map(sample, key, map)
     if 'source_sample' in doc:
         for sample in doc['source_sample']:
+            _map(sample, key, map)
+    if 'source_samples' in doc:
+        for sample in doc['source_samples']:
             _map(sample, key, map)
     if 'ancestors' in doc:
         for ancestor in doc['ancestors']:

--- a/src/hubmap_translation/addl_index_transformations/portal/translate.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/translate.py
@@ -28,6 +28,8 @@ def translate(doc):
     _translate_file_description(doc)
     _translate_status(doc)
     _translate_organ(doc)
+    # _add_origin_samples_unique_mapped_organs depends on the existence of the mapped_organ field and must be performed after _translate_organ.
+    _add_origin_samples_unique_mapped_organs(doc)
     _translate_donor_metadata(doc)
 
     # Remove mapped_specimen_type translation due to new filed sample_category added 12/20/2022 - Zhou
@@ -419,3 +421,17 @@ def _donor_metadata_map(metadata):
         mapped_metadata[f'{key}_unit'].append(kv['units'])
 
     return dict(mapped_metadata)
+
+
+def _get_unique_mapped_organs(samples):
+    '''
+    >>> samples = [{'mapped_organ': 'Lymph Node'}, {'mapped_organ': 'Small Intestine'}, {'mapped_organ': 'Lymph Node'}]
+    >>> sorted(_get_unique_mapped_organs(samples));
+    ['Lymph Node', 'Small Intestine']
+    '''
+    return list({sample['mapped_organ'] for sample in samples if 'mapped_organ' in sample})
+
+
+def _add_origin_samples_unique_mapped_organs(doc):
+    if doc['entity_type'] in ['Sample', 'Dataset'] and 'origin_samples' in doc:
+        doc['origin_samples_unique_mapped_organs'] = _get_unique_mapped_organs(doc['origin_samples'])


### PR DESCRIPTION
We need to switch from the single object `origin_sample` to the array of objects `origin_samples` in the portal ui. We primarily use `origin_sample` to lookup the `mapped_organ` for a dataset or downstream sample, adding this field makes the switch easier. 

Bill gave the OK as the new field is a flat array of strings and doesn't have any of the nested objects that were bloating the documents before.

If approved, once this hits PROD we'll update the portal to only use `origin_samples` and the new field and `origin_sample` can be removed.