### PR TITLE
Use S3 functionality of hubmap-commons for search endpoints

### DIFF
--- a/src/instance/app.cfg.example
+++ b/src/instance/app.cfg.example
@@ -1,3 +1,15 @@
 # Globus app client ID and secret
 APP_CLIENT_ID = ''
 APP_CLIENT_SECRET = ''
+
+# AWS credentials for access such as S3 and presigned URLs
+# https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html
+AWS_ACCESS_KEY_ID = ''
+AWS_SECRET_ACCESS_KEY = ''
+AWS_S3_BUCKET_NAME = 'hm-api-responses'
+AWS_S3_OBJECT_PREFIX = 'Dev_service-api_unspecified-function_'
+AWS_OBJECT_URL_EXPIRATION_IN_SECS = 60*60 # 1 hour
+# Large response threshold, as determined by len() for the character set, above
+# which responses will be stashed in an S3 bucket and a pre-signed URL
+# returned in the response to avoid the AWS Gateway 10Mb constraint
+LARGE_RESPONSE_THRESHOLD = 9*(2**20)

--- a/src/main.py
+++ b/src/main.py
@@ -24,6 +24,12 @@ config['DEFAULT_ELASTICSEARCH_URL'] = config['INDICES']['indices'][config['DEFAU
 config['DEFAULT_ENTITY_API_URL'] = config['INDICES']['indices'][config['DEFAULT_INDEX_WITHOUT_PREFIX']]['document_source_endpoint'].strip('/')
 config['APP_CLIENT_ID'] = app.config['APP_CLIENT_ID']
 config['APP_CLIENT_SECRET'] = app.config['APP_CLIENT_SECRET']
+config['AWS_ACCESS_KEY_ID'] = app.config['AWS_ACCESS_KEY_ID']
+config['AWS_SECRET_ACCESS_KEY'] = app.config['AWS_SECRET_ACCESS_KEY']
+config['AWS_S3_BUCKET_NAME'] = app.config['AWS_S3_BUCKET_NAME']
+config['AWS_S3_OBJECT_PREFIX'] = app.config['AWS_S3_OBJECT_PREFIX']
+config['AWS_OBJECT_URL_EXPIRATION_IN_SECS'] = app.config['AWS_OBJECT_URL_EXPIRATION_IN_SECS']
+config['LARGE_RESPONSE_THRESHOLD'] = app.config['LARGE_RESPONSE_THRESHOLD']
 
 translator_module = importlib.import_module("hubmap_translator")
 


### PR DESCRIPTION
For responses from search() and search_by_index() greater than the AWS Gateway 10Mb limit, stash the results in AWS S3 and return a URL and 303 response, using hubmap-commons support.

Merge straight to main for rapid release. Joe will get to dev-integrate.