### PR TITLE
Add parameterized search endpoints

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "src/search-adaptor"]
 	path = src/search-adaptor
 	url = https://github.com/dbmi-pitt/search-adaptor.git
-	branch = main
+	branch = dev-integrate
 	ignore = dirty

--- a/src/instance/app.cfg.example
+++ b/src/instance/app.cfg.example
@@ -13,3 +13,14 @@ AWS_OBJECT_URL_EXPIRATION_IN_SECS = 60*60 # 1 hour
 # which responses will be stashed in an S3 bucket and a pre-signed URL
 # returned in the response to avoid the AWS Gateway 10Mb constraint
 LARGE_RESPONSE_THRESHOLD = 9*(2**20)
+
+PARAM_SEARCH_RECOGNIZED_ENTITIES_BY_INDEX = {
+    'entities': {
+        'datasets': 'dataset'
+        ,'samples': 'sample'
+        ,'donors': 'donor'
+    }
+    ,'files': {
+        'files': None
+    }
+}

--- a/src/main.py
+++ b/src/main.py
@@ -30,6 +30,7 @@ config['AWS_S3_BUCKET_NAME'] = app.config['AWS_S3_BUCKET_NAME']
 config['AWS_S3_OBJECT_PREFIX'] = app.config['AWS_S3_OBJECT_PREFIX']
 config['AWS_OBJECT_URL_EXPIRATION_IN_SECS'] = app.config['AWS_OBJECT_URL_EXPIRATION_IN_SECS']
 config['LARGE_RESPONSE_THRESHOLD'] = app.config['LARGE_RESPONSE_THRESHOLD']
+config['PARAM_SEARCH_RECOGNIZED_ENTITIES_BY_INDEX'] = app.config['PARAM_SEARCH_RECOGNIZED_ENTITIES_BY_INDEX']
 
 translator_module = importlib.import_module("hubmap_translator")
 


### PR DESCRIPTION
Add parameterized search endpoints.  Exact match "convenience searching" without QDSL payloads.

New AWS Gateway opening for `@self.app.route('/param-search/<entity_type>', methods=['GET'])`
