### PR TITLE
Updating assay_types.yaml to include SIMS-IMS

### DIFF
--- a/src/search-schema/data/definitions/enums/assay_types.yaml
+++ b/src/search-schema/data/definitions/enums/assay_types.yaml
@@ -420,6 +420,13 @@ seqFish_lab_processed:
     vitessce-hints: []
     contains-pii: false
 
+SIMS-IMS:
+  description: SIMS-IMS
+  alt-names: [SIMS]
+  primary: true
+  contains-pii: false
+  vitessce-hints: []
+
 snATACseq:
     description: snATAC-seq
     alt-names: []


### PR DESCRIPTION
Following the merged PR #655 for TEST 
Using name format found in title of this metadata schema (similar to MALDI-IMS): https://hubmapconsortium.github.io/ingest-validation-tools/ims/