### PR TITLE
Add publication_ancillary assay type

### DIFF
--- a/src/search-schema/data/definitions/enums/assay_types.yaml
+++ b/src/search-schema/data/definitions/enums/assay_types.yaml
@@ -286,6 +286,14 @@ publication:
     contains-pii: false
     vitessce-hints: []
 
+publication_ancillary:
+  description: Publication Data [ancillary]
+  alt-names: []
+  primary: false
+  contains-pii: false
+  vis-only: true
+  vitessce-hints: ['json']
+
 bulk-RNA:
     description: Bulk RNA-seq
     alt-names: ['bulk RNA']


### PR DESCRIPTION
This PR adds the publication_ancillary 'assay type' to assay_types.yaml with the goal of supporting visualization of publications.