### PR TITLE
Update portal-visualization to 0.0.11

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -5,7 +5,7 @@ jsonschema==3.2.0
 requests==2.27.1
 PyYAML==5.4.1
 
-git+https://github.com/hubmapconsortium/portal-visualization.git@0.0.10#egg=portal-visualization
+git+https://github.com/hubmapconsortium/portal-visualization.git@0.0.11#egg=portal-visualization
 
 # Use the published package from PyPI as default
 # Use the branch name of commons from github for testing new changes made in commons from different branch


### PR DESCRIPTION
This PR updates the portal-visualization dependency to 0.0.11.

Relates to https://github.com/hubmapconsortium/portal-visualization/pull/78 and https://github.com/hubmapconsortium/portal-ui/pull/3111.