### PR TITLE
Add MIBI_deepcell hints

### DIFF
--- a/src/search-schema/data/definitions/enums/assay_types.yaml
+++ b/src/search-schema/data/definitions/enums/assay_types.yaml
@@ -217,7 +217,7 @@ mibi_deepcell:
   alt-names: []
   primary: false
   contains-pii: false
-  vitessce-hints: ['is_image', 'is_tiled']
+  vitessce-hints: ['is_image', 'is_tiled', 'sprm', 'anndata']
 
 NanoDESI:
   description: NanoDESI


### PR DESCRIPTION
Related to this conversation in #hive-developers: https://hubmapconsortium.slack.com/archives/C011RF3NQ23/p1687546022030299?thread_ts=1687532752.318149&cid=C011RF3NQ23 (if having trouble viewing slack link, copy the link into slack, paste it into the direct messages to yourself, and click through there)

This change will unblock the display of the visualization for all of these datasets: https://portal.hubmapconsortium.org/search?mapped_data_types[0]=CellDIVE%20%5BDeepCell%20%2B%20SPRM%5D&entity_type[0]=Dataset