### PR TITLE
Add group_name to configuration for all entities

### DIFF
--- a/src/hubmap_translation/neo4j-to-es-attributes.json
+++ b/src/hubmap_translation/neo4j-to-es-attributes.json
@@ -185,6 +185,9 @@
     },
     "associated_collection": {
       "es_name": "associated_collection"
+    },
+    "group_name": {
+      "es_name": "group_name"
     }
   }
 }

--- a/src/hubmap_translator.py
+++ b/src/hubmap_translator.py
@@ -878,20 +878,6 @@ class Translator(TranslatorInterface):
 
             self.entity_keys_rename(entity)
 
-            # Is group_uuid always set?
-            # In case if group_name not set
-            if ('group_uuid' in entity) and ('group_name' not in entity):
-                group_uuid = entity['group_uuid']
-
-                # Get the globus groups info based on the groups json file in commons package
-                auth_helper_instance = self.init_auth_helper()
-                globus_groups_info = auth_helper_instance.get_globus_groups_info()
-                groups_by_id_dict = globus_groups_info['by_id']
-                group_dict = groups_by_id_dict[group_uuid]
-
-                # Add new property
-                entity['group_name'] = group_dict['displayname']
-
             # Rename for properties that are objects
             if entity.get('donor', None):
                 self.entity_keys_rename(entity['donor'])


### PR DESCRIPTION
Add group_name to configuration for all entities, which will cover Uploads.  Discard block of code which would remove and re-insert entity properties during translation, since property names are normalized now.