### PR TITLE
John conroy/remove origin sample refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ GET /<index>/count
       "filter": [
         {
           "match": {
-            "origin_sample.entity_type": "Sample"
+            "entity_type.keyword": "Sample"
           }
         }
       ]

--- a/search-api-spec.yaml
+++ b/search-api-spec.yaml
@@ -206,7 +206,7 @@ paths:
       "filter": [
         {
           "match": {
-            "origin_sample.entity_type": "Sample"
+            "entity_type.keyword": "Sample"
           }
         }
       ]
@@ -261,7 +261,7 @@ paths:
       "filter": [
         {
           "match": {
-            "origin_sample.entity_type": "Sample"
+            "entity_type.keyword": "Sample"
           }
         }
       ]

--- a/src/hubmap_translation/addl_index_transformations/portal/__init__.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/__init__.py
@@ -55,9 +55,9 @@ def transform(doc, batch_id='unspecified'):
     ...    'entity_type': 'Dataset',
     ...    'status': 'New',
     ...    'group_name': 'EXT - Outside HuBMAP',
-    ...    'origin_sample': {
+    ...    'origin_samples': [{
     ...        'organ': 'LY'
-    ...    },
+    ...    }],
     ...    'create_timestamp': 1575489509656,
     ...    'ancestor_ids': ['1234', '5678'],
     ...    'ancestors': [{
@@ -107,7 +107,7 @@ def transform(doc, batch_id='unspecified'):
     >>> del transformed['mapper_metadata']
     >>> pprint(transformed)
     {'anatomy_0': ['body'],
-     'anatomy_1': ['large intestine', 'lymph node'],
+     'anatomy_1': ['large intestine'],
      'anatomy_2': ['transverse colon'],
      'ancestor_counts': {'entity_type': {}},
      'ancestor_ids': ['1234', '5678'],
@@ -145,7 +145,8 @@ def transform(doc, batch_id='unspecified'):
                                'keep_this_field': 'Yes!',
                                'should_be_float': 123.456,
                                'should_be_int': 123}},
-     'origin_sample': {'mapped_organ': 'Lymph Node', 'organ': 'LY'},
+     'origin_samples': [{'mapped_organ': 'Lymph Node', 'organ': 'LY'}],
+     'origin_samples_unique_mapped_organs': ['Lymph Node'],
      'rui_location': '{"ccf_annotations": '
                      '["http://purl.obolibrary.org/obo/UBERON_0001157"]}',
      'status': 'New',
@@ -186,7 +187,7 @@ def _map(doc, clean):
     # but better to do it everywhere than to miss one case.
     clean(doc)
 
-    single_valued_fields = ['donor', 'origin_sample', 'source_sample', 'rui_location']
+    single_valued_fields = ['donor', 'source_sample', 'rui_location']
     multi_valued_fields = ['ancestors', 'descendants', 'immediate_ancestors', 'immediate_descendants']
 
     for single_doc_field in single_valued_fields:

--- a/src/hubmap_translation/addl_index_transformations/portal/__init__.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/__init__.py
@@ -187,7 +187,7 @@ def _map(doc, clean):
     # but better to do it everywhere than to miss one case.
     clean(doc)
 
-    single_valued_fields = ['donor', 'source_sample', 'rui_location']
+    single_valued_fields = ['donor', 'rui_location']
     multi_valued_fields = ['ancestors', 'descendants', 'immediate_ancestors', 'immediate_descendants']
 
     for single_doc_field in single_valued_fields:

--- a/src/hubmap_translation/addl_index_transformations/portal/__init__.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/__init__.py
@@ -107,7 +107,7 @@ def transform(doc, batch_id='unspecified'):
     >>> del transformed['mapper_metadata']
     >>> pprint(transformed)
     {'anatomy_0': ['body'],
-     'anatomy_1': ['large intestine'],
+     'anatomy_1': ['large intestine', 'lymph node'],
      'anatomy_2': ['transverse colon'],
      'ancestor_counts': {'entity_type': {}},
      'ancestor_ids': ['1234', '5678'],

--- a/src/hubmap_translation/addl_index_transformations/portal/add_partonomy.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/add_partonomy.py
@@ -17,7 +17,7 @@ _two_letter_to_iri = {
 
 
 def _get_organ_iri(doc):
-    two_letter_code = doc.get('origin_sample', {}).get('organ')
+    two_letter_code = doc.get('origin_samples', [{}])[0].get('organ')
     return _two_letter_to_iri.get(two_letter_code)
 
 
@@ -39,21 +39,21 @@ def add_partonomy(doc):
     {'anatomy_0': ['body'], 'anatomy_1': ['large intestine'], 'anatomy_2': ['transverse colon']}
 
     >>> doc = {
-    ...     'origin_sample': {'organ': 'RK'},
+    ...     'origin_samples': [{'organ': 'RK'}],
     ... }
     >>> add_partonomy(doc)
-    >>> del doc['origin_sample']
+    >>> del doc['origin_samples']
     >>> doc
     {'anatomy_0': ['body'], 'anatomy_1': ['kidney'], 'anatomy_2': ['right kidney']}
 
     If there are both:
 
     >>> doc = {
-    ...     'origin_sample': {'organ': 'RK'},
+    ...     'origin_samples': [{'organ': 'RK'}],
     ...     'rui_location': dumps(rui_location)
     ... }
     >>> add_partonomy(doc)
-    >>> del doc['origin_sample']
+    >>> del doc['origin_samples']
     >>> del doc['rui_location']
     >>> doc
     {'anatomy_0': ['body'], 'anatomy_1': ['kidney', 'large intestine'], 'anatomy_2': ['right kidney', 'transverse colon']}
@@ -61,10 +61,10 @@ def add_partonomy(doc):
     New organ code: No error.
 
     >>> doc = {
-    ...     'origin_sample': {'organ': 'ZZ'},
+    ...     'origin_samples': [{'organ': 'ZZ'}],
     ... }
     >>> add_partonomy(doc)
-    >>> del doc['origin_sample']
+    >>> del doc['origin_samples']
     >>> doc
     {}
 

--- a/src/hubmap_translation/addl_index_transformations/portal/tests/fixtures/input-doc.json
+++ b/src/hubmap_translation/addl_index_transformations/portal/tests/fixtures/input-doc.json
@@ -9,11 +9,6 @@
             "organ": "SI"
         }
     ],
-    "source_sample": [
-        {
-            "organ": "LY"
-        }
-    ],
     "source_samples": [
         {
             "organ": "LY"

--- a/src/hubmap_translation/addl_index_transformations/portal/tests/fixtures/input-doc.json
+++ b/src/hubmap_translation/addl_index_transformations/portal/tests/fixtures/input-doc.json
@@ -1,9 +1,6 @@
 {
     "entity_type": "Dataset",
     "status": "New",
-    "origin_sample": {
-        "organ": "LY"
-    },
     "origin_samples": [
         {
             "organ": "LY"

--- a/src/hubmap_translation/addl_index_transformations/portal/translate.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/translate.py
@@ -54,9 +54,6 @@ def _map(doc, key, map):
     if 'origin_samples' in doc:
         for sample in doc['origin_samples']:
             _map(sample, key, map)
-    if 'source_sample' in doc:
-        for sample in doc['source_sample']:
-            _map(sample, key, map)
     if 'source_samples' in doc:
         for sample in doc['source_samples']:
             _map(sample, key, map)

--- a/src/hubmap_translation/addl_index_transformations/portal/translate.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/translate.py
@@ -51,8 +51,6 @@ def _map(doc, key, map):
         doc[f'mapped_{key}'] = map(doc[key])
     if 'donor' in doc:
         _map(doc['donor'], key, map)
-    if 'origin_sample' in doc:
-        _map(doc['origin_sample'], key, map)
     if 'origin_samples' in doc:
         for sample in doc['origin_samples']:
             _map(sample, key, map)
@@ -242,13 +240,13 @@ def _status_map(status):
 
 def _translate_organ(doc):
     '''
-    >>> doc = {'origin_sample': {'organ': 'RK'}}
+    >>> doc = {'origin_samples': [{'organ': 'RK'}]}
     >>> _translate_organ(doc); doc
-    {'origin_sample': {'organ': 'RK', 'mapped_organ': 'Kidney (Right)'}}
+    {'origin_samples': [{'organ': 'RK', 'mapped_organ': 'Kidney (Right)'}]}
 
-    >>> doc = {'origin_sample': {'organ': 'ZZ'}}
+    >>> doc = {'origin_samples': [{'organ': 'ZZ'}]}
     >>> _translate_organ(doc); doc
-    {'origin_sample': {'organ': 'ZZ', 'mapped_organ': 'No translation for "ZZ"'}}
+    {'origin_samples': [{'organ': 'ZZ', 'mapped_organ': 'No translation for "ZZ"'}]}
 
     '''
     _map(doc, 'organ', _organ_map)

--- a/src/hubmap_translation/neo4j-to-es-attributes.json
+++ b/src/hubmap_translation/neo4j-to-es-attributes.json
@@ -185,6 +185,9 @@
     },
     "associated_collection": {
       "es_name": "associated_collection"
+    },
+    "group_name": {
+      "es_name": "group_name"
     }
   }
 }

--- a/src/hubmap_translator.py
+++ b/src/hubmap_translator.py
@@ -908,20 +908,6 @@ class Translator(TranslatorInterface):
 
             self.entity_keys_rename(entity)
 
-            # Is group_uuid always set?
-            # In case if group_name not set
-            if ('group_uuid' in entity) and ('group_name' not in entity):
-                group_uuid = entity['group_uuid']
-
-                # Get the globus groups info based on the groups json file in commons package
-                auth_helper_instance = self.init_auth_helper()
-                globus_groups_info = auth_helper_instance.get_globus_groups_info()
-                groups_by_id_dict = globus_groups_info['by_id']
-                group_dict = groups_by_id_dict[group_uuid]
-
-                # Add new property
-                entity['group_name'] = group_dict['displayname']
-
             # Rename for properties that are objects
             if entity.get('donor', None):
                 self.entity_keys_rename(entity['donor'])

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -11,7 +11,7 @@ git+https://github.com/hubmapconsortium/portal-visualization.git@0.0.12#egg=port
 # Use the branch name of commons from github for testing new changes made in commons from different branch
 # Default is main branch specified in search-api's docker-compose.development.yml if not set
 # git+https://github.com/hubmapconsortium/commons.git@${COMMONS_BRANCH}#egg=hubmap-commons
-hubmap-commons==2.1.8
+hubmap-commons==2.1.9
 
 # The use of `-r` lets us specify the transitive requirements in one place
 -r search-adaptor/src/requirements.txt

--- a/src/search-schema/data/definitions/fields.yaml
+++ b/src/search-schema/data/definitions/fields.yaml
@@ -194,16 +194,6 @@ organ_other:
   - sample
   enum: null
   required: false
-origin_sample:
-  description: The tissue sample directly below Donor (should usually be an organ)
-    at the top of the provenance chain for the Entity. This conntains, in JSON,
-    the full Entity information for the Sample.
-  entity_types:
-  - sample
-  - dataset
-  - publication
-  enum: null
-  required: Depends on entity type
 origin_samples:
   description: The tissue samples directly below Donor (should usually be an organ)
     at the top of the provenance chain for the Entity. This conntains, in JSON,

--- a/src/search-schema/data/definitions/fields.yaml
+++ b/src/search-schema/data/definitions/fields.yaml
@@ -236,14 +236,6 @@ rui_location:
   - sample
   enum: null
   required: false
-source_sample:
-  description: The tissue sample or samples that the data was directly derived from.  This
-    contains, in JSON, the full Entity information for the Sample.
-  entity_types:
-  - dataset
-  - publication
-  enum: null
-  required: Depends on entity type
 source_samples:
   description: The tissue samples or samples that the data was directly derived from.  This
     contains, in JSON, the full Entity information for the Sample.


### PR DESCRIPTION
This PR removes all references to `origin_sample` and `source_sample`. After talking to Bruce, I've also updated `get_organ_iri` to use the first sample in `origin_samples`. We'll revisit once conversations about multi-assay datasets start and we begin to expect datasets from multiple, different organs.