### PR TITLE
Bump es fields limit from 4000 to 4500

### DIFF
--- a/src/hubmap_translation/addl_index_transformations/portal/config.yaml
+++ b/src/hubmap_translation/addl_index_transformations/portal/config.yaml
@@ -1,6 +1,6 @@
 settings:
   index:
-    mapping.total_fields.limit: 4000
+    mapping.total_fields.limit: 4500
     query.default_field: 2048
 
 mappings:

--- a/src/hubmap_translation/search-default-config.yaml
+++ b/src/hubmap_translation/search-default-config.yaml
@@ -1,6 +1,6 @@
 settings:
   index:
-    mapping.total_fields.limit: 4000
+    mapping.total_fields.limit: 4500
     query.default_field: 2048
 
 mappings:


### PR DESCRIPTION
To mitigate: https://github.com/hubmapconsortium/search-api/issues/686#issuecomment-1668165952