### PR TITLE
Enable re-index of Collections

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -5,7 +5,7 @@ jsonschema==3.2.0
 requests==2.27.1
 PyYAML==5.4.1
 
-git+https://github.com/hubmapconsortium/portal-visualization.git@0.0.12#egg=portal-visualization
+git+https://github.com/hubmapconsortium/portal-visualization.git@0.0.13#egg=portal-visualization
 
 # Use the published package from PyPI as default
 # Use the branch name of commons from github for testing new changes made in commons from different branch


### PR DESCRIPTION
Enable re-index of Collections during POST and PUT calls, in this service and also entity-api.  Allow Collection documents to be put in public and non-public indices, and rename things so they no longer imply only public Collections are indexed.

N.B. this code will refresh the OpenSearch document for any Collection it is given, and counts upon entity-api to prevent update of published Collections.