### PR TITLE
John conroy/transformation errors

### DIFF
--- a/src/hubmap_translation/addl_index_transformations/portal/__init__.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/__init__.py
@@ -60,6 +60,7 @@ def transform(doc, transformation_resources, batch_id='unspecified'):
     # so make a deep copy so we don't surprise the caller.
     _add_validation_errors(doc_copy)
     _clean(doc_copy)
+    doc_copy['transformation_errors'] = []
     try:
         add_assay_details(doc_copy, transformation_resources)
         translate(doc_copy)
@@ -70,6 +71,8 @@ def transform(doc, transformation_resources, batch_id='unspecified'):
     add_counts(doc_copy)
     add_partonomy(doc_copy)
     reset_entity_type(doc_copy)
+    if len(doc_copy['transformation_errors']) == 0:
+        del doc_copy['transformation_errors']
     doc_copy['mapper_metadata'].update({
         'version': _get_version(),
         'datetime': str(datetime.datetime.now()),

--- a/src/hubmap_translation/addl_index_transformations/portal/add_assay_details.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/add_assay_details.py
@@ -22,8 +22,9 @@ def _get_assay_details(doc, transformation_resources):
         raise
     json = response.json()
     if not json:
-        logger.info(f"No soft assay information returned for dataset ${uuid}.")
-        return {'assaytype': 'unknown', 'description': dataset_type, 'vitessce-hints': ['unknown-assay']}
+        empty_error_msg = 'No soft assay information returned.'
+        logger.info(f"${empty_error_msg} for dataset ${uuid}.")
+        return {'description': dataset_type, 'vitessce-hints': ['unknown-assay'], 'error': empty_error_msg}
     return json
 
 
@@ -36,6 +37,10 @@ def add_assay_details(doc, transformation_resources):
         # Remove once the portal-ui has transitioned to use assay_display_name.
         doc['mapped_data_types'] = [assay_details.get('description')]
         doc['vitessce-hints'] = assay_details.get('vitessce-hints')
+
+        error_msg = assay_details.get('error')
+        if error_msg:
+            doc['transformation_errors'].append(error_msg)
 
         def get_assay_type_for_viz(doc):
             return assay_details

--- a/src/hubmap_translation/addl_index_transformations/portal/add_assay_details.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/add_assay_details.py
@@ -23,7 +23,7 @@ def _get_assay_details(doc, transformation_resources):
     json = response.json()
     if not json:
         empty_error_msg = 'No soft assay information returned.'
-        logger.info(f"${empty_error_msg} for dataset ${uuid}.")
+        logger.info(f"${empty_error_msg} For dataset ${uuid}.")
         return {'description': dataset_type, 'vitessce-hints': ['unknown-assay'], 'error': empty_error_msg}
     return json
 

--- a/src/hubmap_translation/addl_index_transformations/portal/add_assay_details.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/add_assay_details.py
@@ -17,15 +17,16 @@ def _get_assay_details(doc, transformation_resources):
     try:
         response = requests.get(
             f'{soft_assay_url}/{uuid}', headers={'Authorization': f'Bearer {token}'})
+        response.raise_for_status()
+        json = response.json()
+        if not json:
+            empty_error_msg = 'No soft assay information returned.'
+            logger.info(f"${empty_error_msg} For dataset ${uuid}.")
+            return {'description': dataset_type, 'vitessce-hints': ['unknown-assay'], 'error': empty_error_msg}
+        return json
     except requests.exceptions.HTTPError as e:
         logger.error(e.response.text)
         raise
-    json = response.json()
-    if not json:
-        empty_error_msg = 'No soft assay information returned.'
-        logger.info(f"${empty_error_msg} For dataset ${uuid}.")
-        return {'description': dataset_type, 'vitessce-hints': ['unknown-assay'], 'error': empty_error_msg}
-    return json
 
 
 def add_assay_details(doc, transformation_resources):

--- a/src/hubmap_translation/addl_index_transformations/portal/tests/test_transform.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/tests/test_transform.py
@@ -148,7 +148,8 @@ def mock_empty_soft_assay(uuid, headers):
 
 expected_output_doc_unknown_assay = expected_output_doc | {'mapped_data_types': [
     'RNAseq [Salmon]'], 'assay_display_name': [
-    'RNAseq [Salmon]'], 'visualization': False, 'vitessce-hints': ['unknown-assay']}
+    'RNAseq [Salmon]'], 'visualization': False, 'vitessce-hints': ['unknown-assay'],
+    'transformation_errors': ['No soft assay information returned.']}
 
 
 def test_transform_unknown_assay(mocker):


### PR DESCRIPTION
Adds `transformation_errors` so we can easily determine for which datasets empty json was returned by the soft assay endpoint.