### PR TITLE
John conroy/additional dataset fields

### DIFF
--- a/src/hubmap_translation/addl_index_transformations/portal/__init__.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/__init__.py
@@ -28,6 +28,10 @@ from hubmap_translation.addl_index_transformations.portal.add_assay_details impo
     add_assay_details
 )
 
+from hubmap_translation.addl_index_transformations.portal.add_dataset_categories import (
+    add_dataset_categories
+)
+
 
 def _get_version():
     # Use the generated BUILD (under project root directory) version (git branch name:short commit hash)
@@ -63,6 +67,7 @@ def transform(doc, transformation_resources, batch_id='unspecified'):
     doc_copy['transformation_errors'] = []
     try:
         add_assay_details(doc_copy, transformation_resources)
+        add_dataset_categories(doc_copy)
         translate(doc_copy)
     except TranslationException as e:
         logging.error(f'Error: {id_for_log}: {e}')

--- a/src/hubmap_translation/addl_index_transformations/portal/__init__.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/__init__.py
@@ -109,17 +109,11 @@ def _map(doc, clean):
     for single_doc_field in single_valued_fields:
         if single_doc_field in doc:
             fragment = doc[single_doc_field]
-            logging.debug(
-                f'Mapping single "{single_doc_field}": {dumps(fragment)[:50]}...')
             _map(fragment, clean)
-            logging.debug(f'... done mapping "{single_doc_field}"')
     for multi_doc_field in multi_valued_fields:
         if multi_doc_field in doc:
             for fragment in doc[multi_doc_field]:
-                logging.debug(
-                    f'Mapping multi "{multi_doc_field}": {dumps(fragment)[:50]}...')
                 _map(fragment, clean)
-                logging.debug(f'... done mapping "{multi_doc_field}"')
 
 
 def _simple_clean(doc):

--- a/src/hubmap_translation/addl_index_transformations/portal/add_assay_details.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/add_assay_details.py
@@ -1,5 +1,6 @@
 import requests
 import logging
+import re
 
 from portal_visualization.builder_factory import has_visualization
 
@@ -33,6 +34,11 @@ def add_assay_details(doc, transformation_resources):
     if 'dataset_type' in doc:
         assay_details = _get_assay_details(doc, transformation_resources)
 
+        doc['raw_dataset_type'] = re.sub(
+            "\\[(.*?)\\]", '', doc['dataset_type']).rstrip()
+
+        if pipeline := re.search("(?<=\\[)[^][]*(?=])", doc['dataset_type']):
+            doc['pipeline'] = pipeline.group()
         # Preserve the previous shape of mapped_data_types.
         doc['assay_display_name'] = [assay_details.get('description')]
         # Remove once the portal-ui has transitioned to use assay_display_name.

--- a/src/hubmap_translation/addl_index_transformations/portal/add_assay_details.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/add_assay_details.py
@@ -38,9 +38,9 @@ def add_assay_details(doc, transformation_resources):
         assay_details = _get_assay_details(doc, transformation_resources)
 
         doc['raw_dataset_type'] = re.sub(
-            "\\[(.*?)\\]", '', doc['dataset_type']).rstrip()
+            "\\[(.*?)\\]", '', doc.get('dataset_type', '')).rstrip()
 
-        if pipeline := re.search("(?<=\\[)[^][]*(?=])", doc['dataset_type']):
+        if pipeline := re.search("(?<=\\[)[^][]*(?=])", doc.get('dataset_type', '')):
             doc['pipeline'] = pipeline.group()
         # Preserve the previous shape of mapped_data_types.
         doc['assay_display_name'] = [assay_details.get('description')]

--- a/src/hubmap_translation/addl_index_transformations/portal/add_assay_details.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/add_assay_details.py
@@ -4,6 +4,10 @@ import re
 
 from portal_visualization.builder_factory import has_visualization
 
+from hubmap_translation.addl_index_transformations.portal.utils import (
+    _log_transformation_error
+)
+
 logging.basicConfig(format='[%(asctime)s] %(levelname)s in %(module)s: %(message)s', level=logging.DEBUG,
                     datefmt='%Y-%m-%d %H:%M:%S')
 logger = logging.getLogger(__name__)
@@ -22,7 +26,6 @@ def _get_assay_details(doc, transformation_resources):
         json = response.json()
         if not json:
             empty_error_msg = 'No soft assay information returned.'
-            logger.info(f"${empty_error_msg} For dataset ${uuid}.")
             return {'description': dataset_type, 'vitessce-hints': ['unknown-assay'], 'error': empty_error_msg}
         return json
     except requests.exceptions.HTTPError as e:
@@ -47,7 +50,7 @@ def add_assay_details(doc, transformation_resources):
 
         error_msg = assay_details.get('error')
         if error_msg:
-            doc['transformation_errors'].append(error_msg)
+            _log_transformation_error(doc, error_msg)
 
         def get_assay_type_for_viz(doc):
             return assay_details

--- a/src/hubmap_translation/addl_index_transformations/portal/add_dataset_categories.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/add_dataset_categories.py
@@ -1,9 +1,8 @@
 from enum import Enum
-import logging
 
-logging.basicConfig(format='[%(asctime)s] %(levelname)s in %(module)s: %(message)s', level=logging.DEBUG,
-                    datefmt='%Y-%m-%d %H:%M:%S')
-logger = logging.getLogger(__name__)
+from hubmap_translation.addl_index_transformations.portal.utils import (
+    _log_transformation_error
+)
 
 
 class CreationAction(str, Enum):
@@ -18,11 +17,6 @@ processing_type_map = {
     CreationAction.CENTRAL_PROCESS: 'hubmap',
     CreationAction.LAB_PROCESS: 'lab',
 }
-
-
-def _log_transformation_error(doc, msg):
-    doc['transformation_errors'].append(msg)
-    logger.info(msg)
 
 
 def _add_dataset_processing_fields(doc):

--- a/src/hubmap_translation/addl_index_transformations/portal/add_dataset_categories.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/add_dataset_categories.py
@@ -1,0 +1,73 @@
+from enum import Enum
+import logging
+
+logging.basicConfig(format='[%(asctime)s] %(levelname)s in %(module)s: %(message)s', level=logging.DEBUG,
+                    datefmt='%Y-%m-%d %H:%M:%S')
+logger = logging.getLogger(__name__)
+
+
+class CreationAction(str, Enum):
+    CREATE_DATASET = 'Create Dataset Activity'
+    MULTI_ASSAY_SPLIT = 'Multi-Assay Split'
+    CENTRAL_PROCESS = 'Central Process'
+    LAB_PROCESS = 'Lab Process'
+    CREATE_PUBLICATION = 'Create Publication Activity'
+
+
+processing_type_map = {
+    CreationAction.CENTRAL_PROCESS: 'hubmap',
+    CreationAction.LAB_PROCESS: 'lab',
+}
+
+
+def _log_transformation_error(doc, msg):
+    doc['transformation_errors'].append(msg)
+    logger.info(msg)
+
+
+def _add_dataset_processing_fields(doc):
+    if processing_type := processing_type_map.get(doc['creation_action']):
+        doc['processing'] = 'processed'
+        doc['processing_type'] = processing_type
+    else:
+        doc['processing'] = 'raw'
+
+
+def _is_component_dataset(doc):
+    if 'creation_action' in doc and doc['creation_action'] == CreationAction.MULTI_ASSAY_SPLIT:
+        return True
+    return False
+
+# Currently only handles primary and component datasets.
+# As multi-assay datasets begin to be processed, we will transition to getting an is_multi_assay bool from soft assay.
+
+
+def _add_multi_assay_fields(doc):
+    if _is_component_dataset(doc):
+        doc['assay_modality'] = 'multiple'
+        doc['multi_assay_category'] = 'component'
+        return
+
+    for descendant_doc in doc['descendants']:
+        if _is_component_dataset(descendant_doc):
+            doc['assay_modality'] = 'multiple'
+            doc['multi_assay_category'] = 'primary'
+            return
+    doc['assay_modality'] = 'single'
+
+
+def add_dataset_categories(doc):
+    if doc['entity_type'] == 'Dataset':
+        creation_action = doc.get('creation_action')
+        if not creation_action:
+            error_msg = "Creation action undefined."
+            _log_transformation_error(doc, error_msg)
+            return
+
+        if creation_action not in {enum.value for enum in CreationAction}:
+            error_msg = f"Unrecognized creation action, {creation_action}."
+            _log_transformation_error(doc, error_msg)
+            return
+
+        _add_dataset_processing_fields(doc)
+        _add_multi_assay_fields(doc)

--- a/src/hubmap_translation/addl_index_transformations/portal/lift_dataset_metadata_fields.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/lift_dataset_metadata_fields.py
@@ -1,0 +1,27 @@
+from hubmap_translation.addl_index_transformations.portal.utils import (
+    _log_transformation_error
+)
+
+
+def _get_analyte_class(doc):
+    metadata = doc.get('metadata', {}).get('metadata', {})
+    return metadata.get('analyte_class')
+
+
+def _lift_analyte_class(doc):
+    if analyte_class := _get_analyte_class(doc):
+        doc['analyte_class'] = analyte_class
+        return
+
+    for ancestor_doc in doc['ancestors']:
+        if analyte_class := _get_analyte_class(ancestor_doc):
+            doc['analyte_class'] = analyte_class
+            return
+
+    _log_transformation_error(
+        doc, 'Analyte_class not found on dataset or dataset ancestors.')
+
+
+def lift_dataset_metadata_fields(doc):
+    if doc['entity_type'] == 'Dataset':
+        _lift_analyte_class(doc)

--- a/src/hubmap_translation/addl_index_transformations/portal/tests/test_add_dataset_categories.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/tests/test_add_dataset_categories.py
@@ -1,0 +1,138 @@
+from hubmap_translation.addl_index_transformations.portal.add_dataset_categories import (
+    add_dataset_categories
+)
+
+
+def test_hubmap_processing():
+    hubmap_processed_input_doc = {
+        'creation_action': 'Central Process',
+        'descendants': [],
+        'entity_type': 'Dataset',
+    }
+
+    hubmap_processed_ouput_doc = {
+        'assay_modality': 'single',
+        'creation_action': 'Central Process',
+        'descendants': [],
+        'entity_type': 'Dataset',
+        'processing': 'processed',
+        'processing_type': 'hubmap',
+    }
+
+    add_dataset_categories(hubmap_processed_input_doc)
+    assert hubmap_processed_input_doc == hubmap_processed_ouput_doc
+
+
+def test_lab_processing():
+    lab_processed_input_doc = {
+        'creation_action': 'Lab Process',
+        'descendants': [],
+        'entity_type': 'Dataset',
+    }
+
+    lab_processed_ouput_doc = {
+        'assay_modality': 'single',
+        'creation_action': 'Lab Process',
+        'descendants': [],
+        'entity_type': 'Dataset',
+        'processing': 'processed',
+        'processing_type': 'lab',
+    }
+    add_dataset_categories(lab_processed_input_doc)
+    assert lab_processed_input_doc == lab_processed_ouput_doc
+
+
+def test_raw():
+    raw_input_doc = {
+        'entity_type': 'Dataset',
+        'creation_action': 'Create Dataset Activity',
+        'descendants': []
+    }
+
+    raw_ouput_doc = {
+        'assay_modality': 'single',
+        'creation_action': 'Create Dataset Activity',
+        'descendants': [],
+        'entity_type': 'Dataset',
+        'processing': 'raw',
+    }
+    add_dataset_categories(raw_input_doc)
+    assert raw_input_doc == raw_ouput_doc
+
+
+def test_component():
+    component_input_doc = {
+        'creation_action': 'Multi-Assay Split',
+        'descendants': [],
+        'entity_type': 'Dataset',
+    }
+
+    component_output_doc = {
+        'assay_modality': 'multiple',
+        'creation_action': 'Multi-Assay Split',
+        'descendants': [],
+        'entity_type': 'Dataset',
+        'multi_assay_category': 'component',
+        'processing': 'raw',
+    }
+    add_dataset_categories(component_input_doc)
+    assert component_input_doc == component_output_doc
+
+
+def test_primary():
+    primary_input_doc = {
+        'creation_action': 'Create Dataset Activity',
+        'descendants': [
+            {
+                'creation_action': 'Multi-Assay Split',
+            }
+        ],
+        'entity_type': 'Dataset',
+    }
+
+    primary_output_doc = {
+        'assay_modality': 'multiple',
+        'creation_action': 'Create Dataset Activity',
+        'descendants': [
+            {
+                'creation_action': 'Multi-Assay Split',
+            }
+        ],
+        'entity_type': 'Dataset',
+        'multi_assay_category': 'primary',
+        'processing': 'raw',
+    }
+    add_dataset_categories(primary_input_doc)
+    assert primary_input_doc == primary_output_doc
+
+
+def test_undefined_creation_action():
+    undefined_creation_action_input_doc = {
+        'entity_type': 'Dataset',
+        'transformation_errors': [],
+    }
+
+    undefined_creation_action_output_doc = {
+        'entity_type': 'Dataset',
+        'transformation_errors': ['Creation action undefined.'],
+    }
+
+    add_dataset_categories(undefined_creation_action_input_doc)
+    assert undefined_creation_action_input_doc == undefined_creation_action_output_doc
+
+
+def test_unknown_creation_action():
+    unknown_creation_action_input_doc = {
+        'creation_action': "Conjure Dataset",
+        'entity_type': 'Dataset',
+        'transformation_errors': [],
+    }
+
+    unknown_creation_action_output_doc = {
+        'creation_action': "Conjure Dataset",
+        'entity_type': 'Dataset',
+        'transformation_errors': ['Unrecognized creation action, Conjure Dataset.'],
+    }
+
+    add_dataset_categories(unknown_creation_action_input_doc)
+    assert unknown_creation_action_input_doc == unknown_creation_action_output_doc

--- a/src/hubmap_translation/addl_index_transformations/portal/tests/test_assay_details.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/tests/test_assay_details.py
@@ -1,0 +1,86 @@
+from hubmap_translation.addl_index_transformations.portal.add_assay_details import (
+    add_assay_details
+)
+
+transformation_resources = {
+    'ingest_api_soft_assay_url': 'abc123', 'token': 'def456'}
+
+
+def mock_soft_assay(uuid, headers):
+    class MockResponse():
+        def __init__(self):
+            self.status_code = 200
+            self.text = 'Logger call requires this'
+
+        def json(self):
+            return {
+                "assaytype": "sciRNAseq",
+                "contains-pii": True,
+                "description": "sciRNA-seq",
+                "dir-schema": "scrnaseq-v0",
+                "primary": True,
+                "tbl-schema": "scrnaseq-v0",
+                "vitessce-hints": []
+            }
+
+        def raise_for_status(self):
+            pass
+    return MockResponse()
+
+
+def test_raw_assay(mocker):
+    mocker.patch('requests.get', side_effect=mock_soft_assay)
+    input_raw_doc = {
+        'uuid': '421007293469db7b528ce6478c00348d',
+        'dataset_type': 'RNAseq',
+    }
+
+    expected_raw_output_doc = {
+        'assay_display_name': ['sciRNA-seq'],
+        'dataset_type': 'RNAseq',
+        'mapped_data_types': ['sciRNA-seq'],
+        'raw_dataset_type': 'RNAseq',
+        'uuid': '421007293469db7b528ce6478c00348d',
+        'vitessce-hints': [],
+        'visualization': False,
+    }
+    add_assay_details(input_raw_doc, transformation_resources)
+    assert input_raw_doc == expected_raw_output_doc
+
+
+def mock_empty_soft_assay(uuid, headers):
+    class MockResponse():
+        def __init__(self):
+            self.status_code = 200
+            self.text = 'Logger call requires this'
+
+        def json(self):
+            return {}
+
+        def raise_for_status(self):
+            pass
+    return MockResponse()
+
+
+def test_transform_unknown_assay(mocker):
+    mocker.patch('requests.get', side_effect=mock_empty_soft_assay)
+
+    unknown_assay_input_doc = {
+        'uuid': '69c70762689b20308bb049ac49653342',
+        'dataset_type': 'RNAseq [Salmon]',
+        'transformation_errors': []
+    }
+
+    unknown_assay_output_doc = {
+        'assay_display_name': ['RNAseq [Salmon]'],
+        'dataset_type': 'RNAseq [Salmon]',
+        'mapped_data_types': ['RNAseq [Salmon]'],
+        'pipeline': 'Salmon',
+        'raw_dataset_type': 'RNAseq',
+        'transformation_errors': ['No soft assay information returned.'],
+        'uuid': '69c70762689b20308bb049ac49653342',
+        'vitessce-hints': ['unknown-assay'],
+        'visualization': False,
+    }
+    add_assay_details(unknown_assay_input_doc, transformation_resources)
+    assert unknown_assay_input_doc == unknown_assay_output_doc

--- a/src/hubmap_translation/addl_index_transformations/portal/tests/test_assay_details.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/tests/test_assay_details.py
@@ -6,7 +6,7 @@ transformation_resources = {
     'ingest_api_soft_assay_url': 'abc123', 'token': 'def456'}
 
 
-def mock_soft_assay(uuid, headers):
+def mock_raw_soft_assay(uuid, headers):
     class MockResponse():
         def __init__(self):
             self.status_code = 200
@@ -28,8 +28,8 @@ def mock_soft_assay(uuid, headers):
     return MockResponse()
 
 
-def test_raw_assay(mocker):
-    mocker.patch('requests.get', side_effect=mock_soft_assay)
+def test_raw_dataset_type(mocker):
+    mocker.patch('requests.get', side_effect=mock_raw_soft_assay)
     input_raw_doc = {
         'uuid': '421007293469db7b528ce6478c00348d',
         'dataset_type': 'RNAseq',
@@ -46,6 +46,53 @@ def test_raw_assay(mocker):
     }
     add_assay_details(input_raw_doc, transformation_resources)
     assert input_raw_doc == expected_raw_output_doc
+
+
+def mock_processed_soft_assay(uuid, headers):
+    class MockResponse():
+        def __init__(self):
+            self.status_code = 200
+            self.text = 'Logger call requires this'
+
+        def json(self):
+            return {
+                "assaytype": "salmon_rnaseq_sciseq",
+                "contains-pii": True,
+                "description": "sciRNA-seq [Salmon]",
+                "primary": False,
+                "vitessce-hints": [
+                    "is_sc",
+                    "rna"
+                ]
+            }
+
+        def raise_for_status(self):
+            pass
+    return MockResponse()
+
+
+def test_processed_dataset_type(mocker):
+    mocker.patch('requests.get', side_effect=mock_processed_soft_assay)
+    input_processed_doc = {
+        'uuid': '22684b9011fc5aea5cb3f89670a461e8',
+        'dataset_type': 'RNAseq [Salmon]',
+    }
+
+    output_processed_doc = {
+        'assay_display_name': ['sciRNA-seq [Salmon]'],
+        'dataset_type': 'RNAseq [Salmon]',
+        'mapped_data_types': ['sciRNA-seq [Salmon]'],
+        'pipeline': 'Salmon',
+        'raw_dataset_type': 'RNAseq',
+        'uuid': '22684b9011fc5aea5cb3f89670a461e8',
+        'vitessce-hints': [
+            "is_sc",
+            "rna"
+        ],
+        'visualization': True,
+    }
+    add_assay_details(input_processed_doc, transformation_resources)
+    assert input_processed_doc == output_processed_doc
 
 
 def mock_empty_soft_assay(uuid, headers):

--- a/src/hubmap_translation/addl_index_transformations/portal/tests/test_lift_dataset_metadata_fields.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/tests/test_lift_dataset_metadata_fields.py
@@ -1,0 +1,76 @@
+from hubmap_translation.addl_index_transformations.portal.lift_dataset_metadata_fields import (
+    lift_dataset_metadata_fields
+)
+
+
+def test_dataset_with_analyte_class():
+    dataset_with_analyte_class_input_doc = {
+        'entity_type': 'Dataset',
+        'metadata': {
+            'metadata': {
+                'analyte_class': 'RNA'
+            }
+        }
+    }
+
+    dataset_with_analyte_class_output_doc = {
+        'analyte_class': 'RNA',
+        'entity_type': 'Dataset',
+        'metadata': {
+            'metadata': {
+                'analyte_class': 'RNA'
+            }
+        }
+    }
+
+    lift_dataset_metadata_fields(dataset_with_analyte_class_input_doc)
+    assert dataset_with_analyte_class_input_doc == dataset_with_analyte_class_output_doc
+
+
+def test_dataset_with_analyte_class_ancestor():
+    dataset_with_analyte_class_ancestor_input_doc = {
+        'ancestors': [
+            {
+                'metadata': {
+                    'metadata': {
+                        'analyte_class': 'RNA'
+                    }
+                }
+            }
+        ],
+        'entity_type': 'Dataset',
+    }
+
+    dataset_with_analyte_class_ancestor_output_doc = {
+        'analyte_class': 'RNA',
+        'ancestors': [
+            {
+                'metadata': {
+                    'metadata': {
+                        'analyte_class': 'RNA'
+                    }
+                }
+            }
+        ],
+        'entity_type': 'Dataset',
+    }
+
+    lift_dataset_metadata_fields(dataset_with_analyte_class_ancestor_input_doc)
+    assert dataset_with_analyte_class_ancestor_input_doc == dataset_with_analyte_class_ancestor_output_doc
+
+
+def test_dataset_without_analyte_class():
+    dataset_without_analyte_class_input_doc = {
+        'ancestors': [],
+        'entity_type': 'Dataset',
+        'transformation_errors': [],
+    }
+
+    dataset_without_analyte_class_output_doc = {
+        'ancestors': [],
+        'entity_type': 'Dataset',
+        'transformation_errors': ['Analyte_class not found on dataset or dataset ancestors.']
+    }
+
+    lift_dataset_metadata_fields(dataset_without_analyte_class_input_doc)
+    assert dataset_without_analyte_class_input_doc == dataset_without_analyte_class_output_doc

--- a/src/hubmap_translation/addl_index_transformations/portal/tests/test_transform.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/tests/test_transform.py
@@ -12,6 +12,7 @@ input_doc = {
         'organ': 'LY'
     }],
     'create_timestamp': 1575489509656,
+    'creation_action': 'Central Process',
     'ancestor_ids': ['1234', '5678'],
     'ancestors': [{
         'sample_category': 'section',
@@ -67,7 +68,9 @@ expected_output_doc = {'anatomy_0': ['body'],
                                       'mapped_sample_category': 'Section',
                                       'sample_category': 'section'}],
                        'assay_display_name': ['scRNA-seq (10x Genomics) [Salmon]'],
+                       'assay_modality': 'single',
                        'create_timestamp': 1575489509656,
+                       'creation_action': 'Central Process',
                        'data_access_level': 'consortium',
                        'dataset_type': 'RNAseq [Salmon]',
                        'descendant_counts': {'entity_type': {'Sample or Dataset': 1}},
@@ -100,6 +103,10 @@ expected_output_doc = {'anatomy_0': ['body'],
                                                  'should_be_int': 123}},
                        'origin_samples': [{'mapped_organ': 'Lymph Node', 'organ': 'LY'}],
                        'origin_samples_unique_mapped_organs': ['Lymph Node'],
+                       'pipeline': 'Salmon',
+                       'processing': 'processed',
+                       'processing_type': 'hubmap',
+                       'raw_dataset_type': 'RNAseq',
                        'rui_location': '{"ccf_annotations": '
                        '["http://purl.obolibrary.org/obo/UBERON_0001157"]}',
                        'status': 'New',
@@ -130,32 +137,3 @@ def test_transform(mocker):
     output = transform(input_doc, transformation_resources)
     del output['mapper_metadata']
     assert output == expected_output_doc
-
-
-def mock_empty_soft_assay(uuid, headers):
-    class MockResponse():
-        def __init__(self):
-            self.status_code = 200
-            self.text = 'Logger call requires this'
-
-        def json(self):
-            return {}
-
-        def raise_for_status(self):
-            pass
-    return MockResponse()
-
-
-expected_output_doc_unknown_assay = expected_output_doc | {'mapped_data_types': [
-    'RNAseq [Salmon]'], 'assay_display_name': [
-    'RNAseq [Salmon]'], 'visualization': False, 'vitessce-hints': ['unknown-assay'],
-    'transformation_errors': ['No soft assay information returned.']}
-
-
-def test_transform_unknown_assay(mocker):
-    mocker.patch('requests.get', side_effect=mock_empty_soft_assay)
-    transformation_resources = {
-        'ingest_api_soft_assay_url': 'abc123', 'token': 'def456'}
-    output = transform(input_doc, transformation_resources)
-    del output['mapper_metadata']
-    assert output == expected_output_doc_unknown_assay

--- a/src/hubmap_translation/addl_index_transformations/portal/tests/test_transform.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/tests/test_transform.py
@@ -42,6 +42,7 @@ input_doc = {
     }],
     'metadata': {
         'metadata': {
+            'analyte_class': 'RNA',
             '_random_stuff_that_should_not_be_ui': 'No!',
             'collectiontype': 'No!',
             'data_path': 'No!',
@@ -59,7 +60,8 @@ input_doc = {
     'rui_location': '{"ccf_annotations": ["http://purl.obolibrary.org/obo/UBERON_0001157"]}',
 }
 
-expected_output_doc = {'anatomy_0': ['body'],
+expected_output_doc = {'analyte_class': 'RNA',
+                       'anatomy_0': ['body'],
                        'anatomy_1': ['large intestine', 'lymph node'],
                        'anatomy_2': ['transverse colon'],
                        'ancestor_counts': {'entity_type': {}},
@@ -95,12 +97,14 @@ expected_output_doc = {'anatomy_0': ['body'],
                        'mapped_external_group_name': 'Outside HuBMAP',
                        'mapped_metadata': {},
                        'mapped_status': 'New',
-                       'metadata': {'dag_provenance_list': [],
-                                    'metadata': {'cell_barcode_size': '123',
-                                                 'is_boolean': 'TRUE',
-                                                 'keep_this_field': 'Yes!',
-                                                 'should_be_float': 123.456,
-                                                 'should_be_int': 123}},
+                       'metadata': {
+                           'dag_provenance_list': [],
+                           'metadata': {'analyte_class': 'RNA',
+                                        'cell_barcode_size': '123',
+                                        'is_boolean': 'TRUE',
+                                        'keep_this_field': 'Yes!',
+                                        'should_be_float': 123.456,
+                                        'should_be_int': 123}},
                        'origin_samples': [{'mapped_organ': 'Lymph Node', 'organ': 'LY'}],
                        'origin_samples_unique_mapped_organs': ['Lymph Node'],
                        'pipeline': 'Salmon',

--- a/src/hubmap_translation/addl_index_transformations/portal/utils.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/utils.py
@@ -1,0 +1,10 @@
+import logging
+
+logging.basicConfig(format='[%(asctime)s] %(levelname)s in %(module)s: %(message)s', level=logging.DEBUG,
+                    datefmt='%Y-%m-%d %H:%M:%S')
+logger = logging.getLogger(__name__)
+
+
+def _log_transformation_error(doc, msg):
+    doc['transformation_errors'].append(msg)
+    logger.info(msg)

--- a/src/hubmap_translation/addl_index_transformations/portal/utils.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/utils.py
@@ -7,4 +7,4 @@ logger = logging.getLogger(__name__)
 
 def _log_transformation_error(doc, msg):
     doc['transformation_errors'].append(msg)
-    logger.info(msg)
+    logger.info(f"doc={doc.get('uuid')}:, {msg}")


### PR DESCRIPTION
Adds a number of fields for datasets to improve search page filtering.

- `raw_dataset_type` which is the `dataset_type` without the pipeline information in brackets.
- `pipeline` which is the pipeline information in brackets removed from `dataset_type`.
- `processing` whether the dataset is 'raw' or 'processed'. Derived from `creation_action`.
- `processing_type` whether the dataset is 'hubmap' or 'lab' processed. Derived from `creation_action`.
- `assay_modality` whether the dataset is single or multi assay.
   - For now this only handles primary or component multi assay datasets by checking for the `creation_action` of 'Multi-Assay Split' on the dataset or its descendants. We will need to coordinate with soft assay developers to get an `is_multi_assay` bool or similar from the soft assay endpoint as they begin processing multi assay datasets.
- `multi_assay_category` whether the multi assay dataset is 'primary' or a 'component'. Processed multi assay datasets will not have this field.
- `analyte_class` is lifted from the dataset metadata to the top level of the document. If the dataset is processed and does not have metadata we get the `analyte_class` from its primary ancestor dataset's metadata.
   - In the future, we will also want to lift the 'Assay Input Entity' for RNAseq and ATACseq datasets as datasets are ingested with the new metadata schema.