### PR TITLE
Fixes "IndexError: list index out of range" in add_partonomy.py.

### DIFF
--- a/src/hubmap_translation/addl_index_transformations/portal/add_partonomy.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/add_partonomy.py
@@ -17,8 +17,10 @@ _two_letter_to_iri = {
 
 
 def _get_organ_iri(doc):
-    two_letter_code = doc.get('origin_samples', [{}])[0].get('organ')
-    return _two_letter_to_iri.get(two_letter_code)
+    origin_samples = doc.get('origin_samples', [])
+    first_sample = origin_samples[0] if origin_samples else {}
+    two_letter_code = first_sample.get('organ', None)
+    return _two_letter_to_iri.get(two_letter_code) if two_letter_code else None
 
 
 def add_partonomy(doc):

--- a/src/hubmap_translation/addl_index_transformations/portal/tests/test_add_partonomy.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/tests/test_add_partonomy.py
@@ -1,0 +1,31 @@
+import pytest
+
+from hubmap_translation.addl_index_transformations.portal.add_partonomy import _get_organ_iri
+
+
+@pytest.mark.parametrize(
+    "doc, expected_organ_iri",
+    [
+        pytest.param(
+            {}, None, id="empty doc"
+        ),
+        pytest.param(
+            {"foo": "bar"}, None, id="missing origin_samples"
+        ),
+        pytest.param(
+            {"origin_samples": []}, None, id="empty origin_samples"
+        ),
+        pytest.param(
+            {"origin_samples": [{"organ": "UT"}]}, None, id="valid organ"
+        ),
+        pytest.param(
+            {"origin_samples": [{"organ": "XX"}]}, None, id="invalid organ"
+        ),
+        pytest.param(
+            {"origin_samples": [{"fake": "XX"}]}, None, id="missing organ"
+        ),
+    ]
+)
+def test_get_organ_iri(doc, expected_organ_iri):
+    organ_iri = _get_organ_iri(doc)
+    assert organ_iri == expected_organ_iri


### PR DESCRIPTION
Fixes "IndexError: list index out of range" in add_partonomy.py when the `origin_samples` field is not available.
Fixes CAT-529.