### PR TITLE
Catch IndexError when a sample or dataset is missing an organ sample.

### DIFF
--- a/src/hubmap_translation/addl_index_transformations/portal/tests/test_add_partonomy.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/tests/test_add_partonomy.py
@@ -11,7 +11,7 @@ from hubmap_translation.addl_index_transformations.portal.translate import Trans
             {}, None, id="empty doc does not throw exception"
         ),
         pytest.param(
-            {"uuid": "test_dataset_uuid", "entity_type": "Donor"}, None, id="Donor is expected to have missing origin_samples"
+            {"uuid": "test_uuid", "entity_type": "Donor"}, None, id="Donor is expected to have missing origin_samples"
         ),
         pytest.param(
             {"uuid": "organ_sample", "entity_type": "Sample", "sample_category": "organ"}, None, id="Organ sample is expected to have missing origin_samples"


### PR DESCRIPTION
This PR addresses the occurrence of "IndexError: list index out of range" when a sample or dataset entity is missing associations to an organ. When this condition occurs, a "TranslationException: Invalid document" message will be logged to state that the document is "Missing or empty 'origin_samples'." The entity will not be added to the portal index to prevent issues on the UI. These entities will be viewable in the ingest portal or data dashboard.