### PR TITLE
Patch to correct source_samples on Dataset document

### DIFF
--- a/src/hubmap_translator.py
+++ b/src/hubmap_translator.py
@@ -919,7 +919,12 @@ class Translator(TranslatorInterface):
 
                         try:
                             if parents[0]['entity_type'] == 'Sample':
-                                entity['source_samples'] = parents
+                                # Inside of this method, only the form of an entity suitable for indexing is supported.
+                                # So use the uuid of the parent Sample to retrieve an indexable document for the Sample.
+                                parent_sample_dict = self.call_entity_api(entity_id=parents[0]['uuid']
+                                                                          ,endpoint='documents')
+
+                                entity['source_samples'] = [parent_sample_dict]
                             e = parents[0]
                         except IndexError:
                             entity['source_samples'] = []


### PR DESCRIPTION
Add extra round-trip to entity-api to get the indexable version of a Sample entity which will be the value of the source_samples list of the OpenSearch document.