### PR TITLE
Nickakhmetov/bump portal vis to v0.2.2

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -10,7 +10,7 @@ PyYAML==5.4.1
 # Will upgrade Flask to newer version later on across all APIs. 10/3/2023 - Zhou
 Werkzeug==2.3.7
 
-git+https://github.com/hubmapconsortium/portal-visualization.git@0.1.0#egg=portal-visualization
+git+https://github.com/hubmapconsortium/portal-visualization.git@0.2.2#egg=portal-visualization
 
 # Use the published package from PyPI as default
 # Use the branch name of commons from github for testing new changes made in commons from different branch


### PR DESCRIPTION
This PR updates the `portal-visualization` version from 0.1.0 to 0.2.2 to make sure that multiome and visium datasets are properly marked as having a matching conf.