### PR TITLE
NickAkhmetov/CAT-665 Adjust visualization flag logic to check descendants

### DIFF
--- a/src/hubmap_translation/addl_index_transformations/portal/add_assay_details.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/add_assay_details.py
@@ -140,9 +140,8 @@ def add_assay_details(doc, transformation_resources):
 
         # Check if the main entity can be visualized by portal-visualization.
         has_viz = has_visualization(doc, get_assay_type_for_viz)
-        if has_viz:
-            doc['visualization'] = True
-        else:
+        doc['visualization'] = has_viz
+        if not has_viz:
             # If an entity doesn't have a visualization,
             # check its descendants for a supporting image pyramid.
             parent_uuid = doc.get('uuid')

--- a/src/hubmap_translation/addl_index_transformations/portal/add_assay_details.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/add_assay_details.py
@@ -157,7 +157,7 @@ def add_assay_details(doc, transformation_resources):
                 'Published', 'QA'].count(descendant['status']) > 0]
             # Sort by the descendant's last modified timestamp, descending
             descendants.sort(
-                key=lambda x: x['last_modified_timestamp'], 
+                key=lambda x: x['last_modified_timestamp'],
                 reverse=True)
             # If any remaining descendants have visualization data, set the parent's visualization to True
             for descendant in descendants:

--- a/src/hubmap_translation/addl_index_transformations/portal/add_assay_details.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/add_assay_details.py
@@ -114,13 +114,13 @@ def _add_dataset_categories(doc, assay_details):
 
 def _get_descendants(doc, transformation_resources):
     descendants_url = transformation_resources.get(
-        'ingest_api_descendants_url')
+        'descendants_url')
     token = transformation_resources.get('token')
     uuid = doc.get('uuid')
 
     try:
         response = requests.get(
-            f'{descendants_url}/{uuid}', headers={'Authorization': f'Bearer {token}'})
+            f'{descendants_url}/{uuid}?property=uuid', headers={'Authorization': f'Bearer {token}'})
         response.raise_for_status()
         return response.json()
     except requests.exceptions.HTTPError as e:

--- a/src/hubmap_translation/addl_index_transformations/portal/add_assay_details.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/add_assay_details.py
@@ -97,8 +97,10 @@ def _add_dataset_categories(doc, assay_details):
         _add_dataset_processing_fields(doc)
         _add_multi_assay_fields(doc, assay_details)
 
+
 def _get_descendants(doc, transformation_resources):
-    descendants_url = transformation_resources.get('ingest_api_descendants_url')
+    descendants_url = transformation_resources.get(
+        'ingest_api_descendants_url')
     token = transformation_resources.get('token')
     uuid = doc.get('uuid')
 
@@ -110,6 +112,7 @@ def _get_descendants(doc, transformation_resources):
     except requests.exceptions.HTTPError as e:
         logger.error(e.response.text)
         raise
+
 
 def add_assay_details(doc, transformation_resources):
     if 'dataset_type' in doc:
@@ -140,7 +143,7 @@ def add_assay_details(doc, transformation_resources):
         if has_viz:
             doc['visualization'] = True
         else:
-            # If an entity doesn't have a visualization, 
+            # If an entity doesn't have a visualization,
             # check its descendants for a supporting image pyramid.
             parent_uuid = doc.get('uuid')
             descendants = _get_descendants(doc, transformation_resources)
@@ -148,14 +151,16 @@ def add_assay_details(doc, transformation_resources):
             # Define a function to get the assay details for a descendant
             def get_assay_type_for_viz(descendant):
                 return _get_assay_details(descendant, transformation_resources)
-            
+
             # Filter any unpublished/non-QA descendants
-            descendants = [descendant for descendant in descendants if ['Published', 'QA'].count(descendant['status']) > 0]
+            descendants = [descendant for descendant in descendants if [
+                'Published', 'QA'].count(descendant['status']) > 0]
             # Sort by the descendant's last modified timestamp, descending
-            descendants.sort(key=lambda x: x['last_modified_timestamp'], reverse=True)
+            descendants.sort(
+                key=lambda x: x['last_modified_timestamp'], 
+                reverse=True)
             # If any remaining descendants have visualization data, set the parent's visualization to True
             for descendant in descendants:
                 if has_visualization(descendant, get_assay_type_for_viz, parent_uuid):
                     doc['visualization'] = True
                     break
-

--- a/src/hubmap_translation/addl_index_transformations/portal/add_assay_details.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/add_assay_details.py
@@ -154,7 +154,7 @@ def add_assay_details(doc, transformation_resources):
 
             # Filter any unpublished/non-QA descendants
             descendants = [descendant for descendant in descendants if [
-                'Published', 'QA'].count(descendant['status']) > 0]
+                'Published', 'QA'].count(descendant.get('status')) > 0]
             # Sort by the descendant's last modified timestamp, descending
             descendants.sort(
                 key=lambda x: x['last_modified_timestamp'],

--- a/src/hubmap_translation/addl_index_transformations/portal/tests/test_assay_details.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/tests/test_assay_details.py
@@ -6,10 +6,31 @@ from hubmap_translation.addl_index_transformations.portal.add_assay_details impo
 )
 
 transformation_resources = {
-    'ingest_api_soft_assay_url': 'abc123', 'token': 'def456'}
+    'ingest_api_soft_assay_url': 'abc123',
+    'ingest_api_descendants_url': 'ghi789',
+    'token': 'def456'
+}
 
 
-def mock_raw_soft_assay(uuid, headers):
+def mock_descendants(descendants_to_mock):
+    class MockDescendantsResponse():
+        def __init__(self):
+            self.status_code = 200
+            self.text = 'Logger call requires this'
+
+        def json(self):
+            return descendants_to_mock
+
+        def raise_for_status(self):
+            pass
+    return MockDescendantsResponse()
+
+
+def empty_descendants():
+    return mock_descendants([])
+
+
+def mock_raw_soft_assay(uuid=None, headers=None):
     class MockResponse():
         def __init__(self):
             self.status_code = 200
@@ -32,7 +53,7 @@ def mock_raw_soft_assay(uuid, headers):
 
 
 def test_raw_dataset_type(mocker):
-    mocker.patch('requests.get', side_effect=mock_raw_soft_assay)
+    mocker.patch('requests.get', side_effect=[mock_raw_soft_assay(), empty_descendants()])
     input_raw_doc = {
         'uuid': '421007293469db7b528ce6478c00348d',
         'dataset_type': 'RNAseq',
@@ -57,7 +78,7 @@ def test_raw_dataset_type(mocker):
     assert input_raw_doc == expected_raw_output_doc
 
 
-def mock_processed_soft_assay(uuid, headers):
+def mock_processed_soft_assay(uuid=None, headers=None):
     class MockResponse():
         def __init__(self):
             self.status_code = 200
@@ -81,7 +102,7 @@ def mock_processed_soft_assay(uuid, headers):
 
 
 def test_processed_dataset_type(mocker):
-    mocker.patch('requests.get', side_effect=mock_processed_soft_assay)
+    mocker.patch('requests.get', side_effect=[mock_processed_soft_assay(), empty_descendants()])
     input_processed_doc = {
         'uuid': '22684b9011fc5aea5cb3f89670a461e8',
         'dataset_type': 'RNAseq [Salmon]',
@@ -111,7 +132,7 @@ def test_processed_dataset_type(mocker):
     assert input_processed_doc == output_processed_doc
 
 
-def mock_empty_soft_assay(uuid, headers):
+def mock_empty_soft_assay(uuid=None, headers=None):
     class MockResponse():
         def __init__(self):
             self.status_code = 200
@@ -126,7 +147,7 @@ def mock_empty_soft_assay(uuid, headers):
 
 
 def test_transform_unknown_assay(mocker):
-    mocker.patch('requests.get', side_effect=mock_empty_soft_assay)
+    mocker.patch('requests.get', side_effect=[mock_empty_soft_assay(), empty_descendants()])
 
     unknown_assay_input_doc = {
         'uuid': '69c70762689b20308bb049ac49653342',

--- a/src/hubmap_translation/addl_index_transformations/portal/tests/test_assay_details.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/tests/test_assay_details.py
@@ -7,7 +7,7 @@ from hubmap_translation.addl_index_transformations.portal.add_assay_details impo
 
 transformation_resources = {
     'ingest_api_soft_assay_url': 'abc123',
-    'ingest_api_descendants_url': 'ghi789',
+    'descendants_url': 'ghi789',
     'token': 'def456'
 }
 

--- a/src/hubmap_translation/addl_index_transformations/portal/tests/test_assay_details.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/tests/test_assay_details.py
@@ -12,7 +12,7 @@ transformation_resources = {
 }
 
 
-def mock_response(response_to_mock, status_code = 200, text = 'Logger call requires this'):
+def mock_response(response_to_mock, status_code=200, text='Logger call requires this'):
     class MockResponse():
         def __init__(self):
             self.status_code = status_code

--- a/src/hubmap_translation/addl_index_transformations/portal/tests/test_assay_details.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/tests/test_assay_details.py
@@ -12,50 +12,40 @@ transformation_resources = {
 }
 
 
-def mock_descendants(descendants_to_mock):
-    class MockDescendantsResponse():
-        def __init__(self):
-            self.status_code = 200
-            self.text = 'Logger call requires this'
-
-        def json(self):
-            return descendants_to_mock
-
-        def raise_for_status(self):
-            pass
-    return MockDescendantsResponse()
-
-
-def empty_descendants():
-    return mock_descendants([])
-
-
-def mock_raw_soft_assay(uuid=None, headers=None):
+def mock_response(response_to_mock, status_code = 200, text = 'Logger call requires this'):
     class MockResponse():
         def __init__(self):
-            self.status_code = 200
-            self.text = 'Logger call requires this'
+            self.status_code = status_code
+            self.text = text
 
         def json(self):
-            return {
-                "assaytype": "sciRNAseq",
-                "contains-pii": True,
-                "description": "sciRNA-seq",
-                "dir-schema": "scrnaseq-v0",
-                "primary": True,
-                "tbl-schema": "scrnaseq-v0",
-                "vitessce-hints": []
-            }
+            return response_to_mock
 
         def raise_for_status(self):
             pass
     return MockResponse()
 
 
+def mock_empty_descendants():
+    return mock_response([])
+
+
+def mock_raw_soft_assay(uuid=None, headers=None):
+    return mock_response({
+        "assaytype": "sciRNAseq",
+        "contains-pii": True,
+        "description": "sciRNA-seq",
+        "dir-schema": "scrnaseq-v0",
+        "primary": True,
+        "tbl-schema": "scrnaseq-v0",
+        "vitessce-hints": []
+    })
+
+
 def test_raw_dataset_type(mocker):
     mocker.patch('requests.get', side_effect=[
                  mock_raw_soft_assay(),
-                 empty_descendants()])
+                 mock_empty_descendants()])
     input_raw_doc = {
         'uuid': '421007293469db7b528ce6478c00348d',
         'dataset_type': 'RNAseq',
@@ -81,32 +71,22 @@ def test_raw_dataset_type(mocker):
 
 
 def mock_processed_soft_assay(uuid=None, headers=None):
-    class MockResponse():
-        def __init__(self):
-            self.status_code = 200
-            self.text = 'Logger call requires this'
-
-        def json(self):
-            return {
-                "assaytype": "salmon_rnaseq_sciseq",
-                "contains-pii": True,
-                "description": "sciRNA-seq [Salmon]",
-                "primary": False,
-                "vitessce-hints": [
-                    "is_sc",
-                    "rna"
-                ]
-            }
-
-        def raise_for_status(self):
-            pass
-    return MockResponse()
+    return mock_response({
+        "assaytype": "salmon_rnaseq_sciseq",
+        "contains-pii": True,
+        "description": "sciRNA-seq [Salmon]",
+        "primary": False,
+        "vitessce-hints": [
+            "is_sc",
+            "rna"
+        ]
+    })
 
 
 def test_processed_dataset_type(mocker):
     mocker.patch('requests.get', side_effect=[
                  mock_processed_soft_assay(),
-                 empty_descendants()])
+                 mock_empty_descendants()])
     input_processed_doc = {
         'uuid': '22684b9011fc5aea5cb3f89670a461e8',
         'dataset_type': 'RNAseq [Salmon]',
@@ -137,23 +117,13 @@ def test_processed_dataset_type(mocker):
 
 
 def mock_empty_soft_assay(uuid=None, headers=None):
-    class MockResponse():
-        def __init__(self):
-            self.status_code = 200
-            self.text = 'Logger call requires this'
-
-        def json(self):
-            return {}
-
-        def raise_for_status(self):
-            pass
-    return MockResponse()
+    return mock_response({})
 
 
 def test_transform_unknown_assay(mocker):
     mocker.patch('requests.get', side_effect=[
                  mock_empty_soft_assay(),
-                 empty_descendants()])
+                 mock_empty_descendants()])
 
     unknown_assay_input_doc = {
         'uuid': '69c70762689b20308bb049ac49653342',
@@ -184,85 +154,53 @@ def test_transform_unknown_assay(mocker):
 
 
 def mock_image_pyramid_parent(uuid=None, headers=None):
-    class MockResponse():
-        def __init__(self):
-            self.status_code = 200
-            self.text = 'Logger call requires this'
-
-        def json(self):
-            return {
-                "assaytype": "PAS",
-                "contains-pii": False,
-                "dataset-type": "Histology",
-                "description": "PAS Stained Microscopy",
-                "dir-schema": "stained-v0",
-                "primary": True,
-                "tbl-schema": "stained-v0",
-                "vitessce-hints": []
-            }
-
-        def raise_for_status(self):
-            pass
-
-    return MockResponse()
+    return mock_response({
+        "assaytype": "PAS",
+        "contains-pii": False,
+        "dataset-type": "Histology",
+        "description": "PAS Stained Microscopy",
+        "dir-schema": "stained-v0",
+        "primary": True,
+        "tbl-schema": "stained-v0",
+        "vitessce-hints": []
+    })
 
 
 def mock_image_pyramid_descendants(uuid=None, headers=None):
-    class MockResponse():
-        def __init__(self):
-            self.status_code = 200
-            self.text = 'Logger call requires this'
-
-        def json(self):
-            return [
-                # Newer descendant which is not published and gets ignored
-                {
-                    "uuid": "8adc3c31ca84ec4b958ed20a7c4f4920",
-                    "status": "New",
-                    "last_modified_timestamp": 1234567891,
-                },
-                # Good descendant
-                {
-                    "uuid": "8adc3c31ca84ec4b958ed20a7c4f4919",
-                    "status": "Published",
-                    "last_modified_timestamp": 1234567890,
-                },
-                # Older descendant which is published but gets ignored due to newer descendant
-                {
-                    "uuid": "8adc3c31ca84ec4b958ed20a7c4f4918",
-                    "status": "Published",
-                    "last_modified_timestamp": 1234567889,
-                }
-            ]
-
-        def raise_for_status(self):
-            pass
-
-    return MockResponse()
+    return mock_response([
+        # Newer descendant which is not published and gets ignored
+        {
+            "uuid": "8adc3c31ca84ec4b958ed20a7c4f4920",
+            "status": "New",
+            "last_modified_timestamp": 1234567891,
+        },
+        # Good descendant
+        {
+            "uuid": "8adc3c31ca84ec4b958ed20a7c4f4919",
+            "status": "Published",
+            "last_modified_timestamp": 1234567890,
+        },
+        # Older descendant which is published but gets ignored due to newer descendant
+        {
+            "uuid": "8adc3c31ca84ec4b958ed20a7c4f4918",
+            "status": "Published",
+            "last_modified_timestamp": 1234567889,
+        }
+    ])
 
 
 def mock_image_pyramid_support(uuid=None, headers=None):
-    class MockResponse():
-        def __init__(self):
-            self.status_code = 200
-            self.text = 'Logger call requires this'
-
-        def json(self):
-            return {
-                "assaytype": "image_pyramid",
-                "contains-pii": False,
-                "description": "Image Pyramid",
-                "primary": False,
-                "vitessce-hints": [
-                    "is_image",
-                    "is_support",
-                    "pyramid"
-                ]
-            }
-
-        def raise_for_status(self):
-            pass
-    return MockResponse()
+    return mock_response({
+        "assaytype": "image_pyramid",
+        "contains-pii": False,
+        "description": "Image Pyramid",
+        "primary": False,
+        "vitessce-hints": [
+            "is_image",
+            "is_support",
+            "pyramid"
+        ]
+    })
 
 
 def test_transform_image_pyramid(mocker):

--- a/src/hubmap_translation/addl_index_transformations/portal/tests/test_assay_details.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/tests/test_assay_details.py
@@ -53,7 +53,9 @@ def mock_raw_soft_assay(uuid=None, headers=None):
 
 
 def test_raw_dataset_type(mocker):
-    mocker.patch('requests.get', side_effect=[mock_raw_soft_assay(), empty_descendants()])
+    mocker.patch('requests.get', side_effect=[
+                 mock_raw_soft_assay(),
+                 empty_descendants()])
     input_raw_doc = {
         'uuid': '421007293469db7b528ce6478c00348d',
         'dataset_type': 'RNAseq',
@@ -102,7 +104,9 @@ def mock_processed_soft_assay(uuid=None, headers=None):
 
 
 def test_processed_dataset_type(mocker):
-    mocker.patch('requests.get', side_effect=[mock_processed_soft_assay(), empty_descendants()])
+    mocker.patch('requests.get', side_effect=[
+                 mock_processed_soft_assay(),
+                 empty_descendants()])
     input_processed_doc = {
         'uuid': '22684b9011fc5aea5cb3f89670a461e8',
         'dataset_type': 'RNAseq [Salmon]',
@@ -147,7 +151,9 @@ def mock_empty_soft_assay(uuid=None, headers=None):
 
 
 def test_transform_unknown_assay(mocker):
-    mocker.patch('requests.get', side_effect=[mock_empty_soft_assay(), empty_descendants()])
+    mocker.patch('requests.get', side_effect=[
+                 mock_empty_soft_assay(),
+                 empty_descendants()])
 
     unknown_assay_input_doc = {
         'uuid': '69c70762689b20308bb049ac49653342',
@@ -177,6 +183,125 @@ def test_transform_unknown_assay(mocker):
     assert unknown_assay_input_doc == unknown_assay_output_doc
 
 
+def mock_image_pyramid_parent(uuid=None, headers=None):
+    class MockResponse():
+        def __init__(self):
+            self.status_code = 200
+            self.text = 'Logger call requires this'
+
+        def json(self):
+            return {
+                "assaytype": "PAS",
+                "contains-pii": False,
+                "dataset-type": "Histology",
+                "description": "PAS Stained Microscopy",
+                "dir-schema": "stained-v0",
+                "primary": True,
+                "tbl-schema": "stained-v0",
+                "vitessce-hints": []
+            }
+
+        def raise_for_status(self):
+            pass
+
+    return MockResponse()
+
+
+def mock_image_pyramid_descendants(uuid=None, headers=None):
+    class MockResponse():
+        def __init__(self):
+            self.status_code = 200
+            self.text = 'Logger call requires this'
+
+        def json(self):
+            return [
+                # Newer descendant which is not published and gets ignored
+                {
+                    "uuid": "8adc3c31ca84ec4b958ed20a7c4f4920",
+                    "status": "New",
+                    "last_modified_timestamp": 1234567891,
+                },
+                # Good descendant
+                {
+                    "uuid": "8adc3c31ca84ec4b958ed20a7c4f4919",
+                    "status": "Published",
+                    "last_modified_timestamp": 1234567890,
+                },
+                # Older descendant which is published but gets ignored due to newer descendant
+                {
+                    "uuid": "8adc3c31ca84ec4b958ed20a7c4f4918",
+                    "status": "Published",
+                    "last_modified_timestamp": 1234567889,
+                }
+            ]
+
+        def raise_for_status(self):
+            pass
+
+    return MockResponse()
+
+
+def mock_image_pyramid_support(uuid=None, headers=None):
+    class MockResponse():
+        def __init__(self):
+            self.status_code = 200
+            self.text = 'Logger call requires this'
+
+        def json(self):
+            return {
+                "assaytype": "image_pyramid",
+                "contains-pii": False,
+                "description": "Image Pyramid",
+                "primary": False,
+                "vitessce-hints": [
+                    "is_image",
+                    "is_support",
+                    "pyramid"
+                ]
+            }
+
+        def raise_for_status(self):
+            pass
+    return MockResponse()
+
+
+def test_transform_image_pyramid(mocker):
+    mocker.patch('requests.get', side_effect=[
+        # initial request to has_visualization with parent entity
+        mock_image_pyramid_parent(),
+        # request to get descendants of parent entity
+        mock_image_pyramid_descendants(),
+        # request to get assay details of descendant entity
+        mock_image_pyramid_support(),
+        # portal-visualization re-requests parent entity details
+        # to determine which type of image pyramid it is
+        mock_image_pyramid_parent(),
+    ])
+    image_pyramid_input_doc = {
+        'uuid': '69c70762689b20308bb049ac49653342',
+        'dataset_type': 'PAS',
+        'entity_type': 'Dataset',
+        'creation_action': 'Create Dataset Activity'
+    }
+
+    image_pyramid_output_doc = {
+        'assay_display_name': ['PAS Stained Microscopy'],
+        'assay_modality': 'single',
+        'creation_action': 'Create Dataset Activity',
+        'dataset_type': 'PAS',
+        'mapped_data_types': ['PAS Stained Microscopy'],
+        "processing": "raw",
+        'raw_dataset_type': 'PAS',
+        'uuid': '69c70762689b20308bb049ac49653342',
+        'vitessce-hints': [],
+        'visualization': True,
+        'entity_type': 'Dataset',
+    }
+
+    add_assay_details(image_pyramid_input_doc, transformation_resources)
+    assert image_pyramid_input_doc == image_pyramid_output_doc
+
+
 def test_hubmap_processing():
     hubmap_processed_input_doc = {
         'creation_action': 'Central Process',
@@ -184,7 +309,7 @@ def test_hubmap_processing():
         'entity_type': 'Dataset',
     }
 
-    hubmap_processed_ouput_doc = {
+    hubmap_processed_output_doc = {
         'assay_modality': 'single',
         'creation_action': 'Central Process',
         'descendants': [],
@@ -194,7 +319,7 @@ def test_hubmap_processing():
     }
 
     _add_dataset_categories(hubmap_processed_input_doc, {})
-    assert hubmap_processed_input_doc == hubmap_processed_ouput_doc
+    assert hubmap_processed_input_doc == hubmap_processed_output_doc
 
 
 def test_lab_processing():
@@ -204,7 +329,7 @@ def test_lab_processing():
         'entity_type': 'Dataset',
     }
 
-    lab_processed_ouput_doc = {
+    lab_processed_output_doc = {
         'assay_modality': 'single',
         'creation_action': 'Lab Process',
         'descendants': [],
@@ -213,7 +338,7 @@ def test_lab_processing():
         'processing_type': 'lab',
     }
     _add_dataset_categories(lab_processed_input_doc, {})
-    assert lab_processed_input_doc == lab_processed_ouput_doc
+    assert lab_processed_input_doc == lab_processed_output_doc
 
 
 @pytest.mark.parametrize(

--- a/src/hubmap_translator.py
+++ b/src/hubmap_translator.py
@@ -69,7 +69,6 @@ class Translator(TranslatorInterface):
     def __init__(self, indices, app_client_id, app_client_secret, token, ontology_api_base_url:str=None):
         try:
             self.ingest_api_soft_assay_url = indices['ingest_api_soft_assay_url'].strip('/')
-            self.ingest_api_descendants_url = indices['ingest_api_descendants_url'].strip('/')
             self.indices: dict = {}
             self.self_managed_indices: dict = {}
             # Do not include the indexes that are self managed
@@ -98,7 +97,7 @@ class Translator(TranslatorInterface):
         # Add index_version by parsing the VERSION file
         self.index_version = ((Path(__file__).absolute().parent.parent / 'VERSION').read_text()).strip()
         self.transformation_resources = {'ingest_api_soft_assay_url': self.ingest_api_soft_assay_url,
-                                         'ingest_api_descendants_url': self.ingest_api_descendants_url,
+                                         'descendants_url': f'{self.entity_api_url}"/descendants"',
                                          'token': token,}
 
         # # Preload all the transformers

--- a/src/hubmap_translator.py
+++ b/src/hubmap_translator.py
@@ -69,6 +69,7 @@ class Translator(TranslatorInterface):
     def __init__(self, indices, app_client_id, app_client_secret, token, ontology_api_base_url:str=None):
         try:
             self.ingest_api_soft_assay_url = indices['ingest_api_soft_assay_url'].strip('/')
+            self.ingest_api_descendants_url = indices['ingest_api_descendants_url'].strip('/')
             self.indices: dict = {}
             self.self_managed_indices: dict = {}
             # Do not include the indexes that are self managed
@@ -96,7 +97,9 @@ class Translator(TranslatorInterface):
         self.entity_api_url = self.indices[self.DEFAULT_INDEX_WITHOUT_PREFIX]['document_source_endpoint'].strip('/')
         # Add index_version by parsing the VERSION file
         self.index_version = ((Path(__file__).absolute().parent.parent / 'VERSION').read_text()).strip()
-        self.transformation_resources = {'ingest_api_soft_assay_url': self.ingest_api_soft_assay_url, 'token': token}
+        self.transformation_resources = {'ingest_api_soft_assay_url': self.ingest_api_soft_assay_url,
+                                         'ingest_api_descendants_url': self.ingest_api_descendants_url,
+                                         'token': token,}
 
         # # Preload all the transformers
         self.init_transformers()

--- a/src/instance/search-config.yaml.example
+++ b/src/instance/search-config.yaml.example
@@ -4,6 +4,9 @@
 # Soft assay support via ingest-api GET /assaytype/<dataset-id> endpoint
 # Omit the <dataset-id> in this config 
 ingest_api_soft_assay_url: https://ingest-api.dev.hubmapconsortium.org/assaytype/ 
+# Descendants support via ingest-api GET /descendants/<dataset-id> endpoint
+# Omit the <dataset-id> in this config 
+ingest_api_descendants_url: https://ingest-api.dev.hubmapconsortium.org/descendants/ 
 
 # default index name for endpoints that don't specify an index
 default_index: entities

--- a/src/instance/search-config.yaml.example
+++ b/src/instance/search-config.yaml.example
@@ -4,10 +4,6 @@
 # Soft assay support via ingest-api GET /assaytype/<dataset-id> endpoint
 # Omit the <dataset-id> in this config 
 ingest_api_soft_assay_url: https://ingest-api.dev.hubmapconsortium.org/assaytype/ 
-# Descendants support via ingest-api GET /descendants/<dataset-id> endpoint
-# Omit the <dataset-id> in this config 
-ingest_api_descendants_url: https://ingest-api.dev.hubmapconsortium.org/descendants/ 
-
 # default index name for endpoints that don't specify an index
 default_index: entities
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -10,7 +10,7 @@ PyYAML==5.4.1
 # Will upgrade Flask to newer version later on across all APIs. 10/3/2023 - Zhou
 Werkzeug==2.3.7
 
-git+https://github.com/hubmapconsortium/portal-visualization.git@0.2.2#egg=portal-visualization
+git+https://github.com/hubmapconsortium/portal-visualization.git@0.2.5#egg=portal-visualization
 
 # Use the published package from PyPI as default
 # Use the branch name of commons from github for testing new changes made in commons from different branch


### PR DESCRIPTION
This PR:
- Bumps portal-visualization to 0.2.5 (to pull in changes to the `has_visualization` function to allow usage of parent UUIDs)
- Adjusts the `visualization` flag logic so that it performs vislifting to take into account whether the dataset has supporting image pyramid entities which can be visualized.

This change will require the addition of the entity API descendants URL to the search_config.yaml for each environment (`ingest_api_descendants_url`, following the convention set by the soft assay URL).