### PR TITLE
Remove `?property=uuid` to avoid broken descendant lookups

### DIFF
--- a/src/hubmap_translation/addl_index_transformations/portal/add_assay_details.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/add_assay_details.py
@@ -120,7 +120,7 @@ def _get_descendants(doc, transformation_resources):
 
     try:
         response = requests.get(
-            f'{descendants_url}/{uuid}?property=uuid', headers={'Authorization': f'Bearer {token}'})
+            f'{descendants_url}/{uuid}', headers={'Authorization': f'Bearer {token}'})
         response.raise_for_status()
         return response.json()
     except requests.exceptions.HTTPError as e:


### PR DESCRIPTION
This PR rolls back an experimental change I accidentally included with my lint fixes while iterating on #804.