### PR TITLE
John conroy/ addl soft assay fields

### DIFF
--- a/src/hubmap_translation/addl_index_transformations/portal/add_assay_details.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/add_assay_details.py
@@ -137,8 +137,13 @@ def add_assay_details(doc, transformation_resources):
         doc['raw_dataset_type'] = re.sub(
             "\\[(.*?)\\]", '', doc.get('dataset_type', '')).rstrip()
 
-        if pipeline := re.search("(?<=\\[)[^][]*(?=])", doc.get('dataset_type', '')):
+        if pipeline := assay_details.get('pipeline-shorthand'):
+            doc['pipeline'] = pipeline
+        elif pipeline := re.search("(?<=\\[)[^][]*(?=])", doc.get('dataset_type', '')):
             doc['pipeline'] = pipeline.group()
+
+        if soft_assaytype := assay_details.get('assaytype'):
+            doc['soft_assaytype'] = soft_assaytype
         # Preserve the previous shape of mapped_data_types.
         doc['assay_display_name'] = [assay_details.get('description')]
         # Remove once the portal-ui has transitioned to use assay_display_name.

--- a/src/hubmap_translation/addl_index_transformations/portal/add_assay_details.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/add_assay_details.py
@@ -135,7 +135,7 @@ def _add_pipeline(doc, assay_details):
         doc['pipeline'] = pipeline
     #  pipeline-shorthand is not returned for EPICs.
     elif doc.get('processing_type') == 'external':
-        doc[pipeline] = assay_details.get('description')
+        doc['pipeline'] = assay_details.get('description')
     #  pipeline-shorthand is not returned for Image Pyramids.
     elif set(['pyramid', 'is_image']).issubset(set(assay_details.get('vitessce-hints'))):
         doc['pipeline'] = 'Image Pyramid'

--- a/src/hubmap_translation/addl_index_transformations/portal/tests/test_assay_details.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/tests/test_assay_details.py
@@ -282,6 +282,58 @@ def test_transform_image_pyramid_support(mocker):
     assert image_pyramid_input_doc == image_pyramid_output_doc
 
 
+def mock_epic(uuid=None, headers=None):
+    return mock_response({
+        "assaytype": None,
+        "description": "Segmentation Mask",
+        "is-multi-assay": False,
+        "pipeline-shorthand": "",
+        "primary": False,
+        "vitessce-hints": [
+            "segmentation_mask",
+            "is_image",
+            "pyramid"
+        ]
+    })
+
+
+def test_transform_epic(mocker):
+    mocker.patch('requests.get', side_effect=[
+        mock_epic(),
+        mock_empty_descendants(),
+    ])
+    epic_input_doc = {
+        'uuid': 'abc123',
+        'dataset_type': 'Segmentation Mask',
+        'entity_type': 'Dataset',
+        'creation_action': 'External Process'
+    }
+
+    epic_output_doc = {
+        'assay_display_name': ['Segmentation Mask'],
+        'assay_modality': 'single',
+        'creation_action': 'External Process',
+        'dataset_type': 'Segmentation Mask',
+        'mapped_data_types': ['Segmentation Mask'],
+        "processing": "processed",
+        'raw_dataset_type': 'Segmentation Mask',
+        'uuid': 'abc123',
+        'pipeline': 'Segmentation Mask',
+        'processing_type': 'external',
+        'vitessce-hints': [
+            "segmentation_mask",
+            "is_image",
+            "pyramid",
+
+        ],
+        'visualization': False,
+        'entity_type': 'Dataset',
+    }
+
+    add_assay_details(epic_input_doc, transformation_resources)
+    assert epic_input_doc == epic_output_doc
+
+
 def test_hubmap_processing():
     hubmap_processed_input_doc = {
         'creation_action': 'Central Process',

--- a/src/hubmap_translation/addl_index_transformations/portal/tests/test_assay_details.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/tests/test_assay_details.py
@@ -206,7 +206,7 @@ def mock_image_pyramid_support(uuid=None, headers=None):
     })
 
 
-def test_transform_image_pyramid(mocker):
+def test_transform_image_pyramid_parent(mocker):
     mocker.patch('requests.get', side_effect=[
         # initial request to has_visualization with parent entity
         mock_image_pyramid_parent(),
@@ -237,6 +237,44 @@ def test_transform_image_pyramid(mocker):
         'vitessce-hints': [],
         'visualization': True,
         "soft_assaytype": "PAS",
+        'entity_type': 'Dataset',
+    }
+
+    add_assay_details(image_pyramid_input_doc, transformation_resources)
+    assert image_pyramid_input_doc == image_pyramid_output_doc
+
+
+def test_transform_image_pyramid_support(mocker):
+    mocker.patch('requests.get', side_effect=[
+        mock_image_pyramid_support(),
+        mock_empty_descendants(),
+    ])
+    image_pyramid_input_doc = {
+        'uuid': '0bf9cb40adebcfb261dfbe9244607508',
+        'dataset_type': 'Histology [Image Pyramid]',
+        'entity_type': 'Dataset',
+        'creation_action': 'Central Process'
+    }
+
+    image_pyramid_output_doc = {
+        'assay_display_name': ['Image Pyramid'],
+        'assay_modality': 'single',
+        'creation_action': 'Central Process',
+        'dataset_type': 'Histology [Image Pyramid]',
+        'mapped_data_types': ['Image Pyramid'],
+        "processing": "processed",
+        'raw_dataset_type': 'Histology',
+        'uuid': '0bf9cb40adebcfb261dfbe9244607508',
+        'pipeline': 'Image Pyramid',
+        'processing_type': 'hubmap',
+        'vitessce-hints': [
+            "is_image",
+            "is_support",
+            "pyramid",
+
+        ],
+        'visualization': False,
+        "soft_assaytype": "image_pyramid",
         'entity_type': 'Dataset',
     }
 

--- a/src/hubmap_translation/addl_index_transformations/portal/tests/test_assay_details.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/tests/test_assay_details.py
@@ -64,7 +64,8 @@ def test_raw_dataset_type(mocker):
         'entity_type': 'Dataset',
         'assay_modality': 'single',
         'creation_action': 'Create Dataset Activity',
-        'processing': 'raw'
+        'processing': 'raw',
+        'soft_assaytype': 'sciRNAseq'
     }
     add_assay_details(input_raw_doc, transformation_resources)
     assert input_raw_doc == expected_raw_output_doc
@@ -74,6 +75,7 @@ def mock_processed_soft_assay(uuid=None, headers=None):
     return mock_response({
         "assaytype": "salmon_rnaseq_sciseq",
         "contains-pii": True,
+        "pipeline-shorthand": "Salmon",
         "description": "sciRNA-seq [Salmon]",
         "primary": False,
         "vitessce-hints": [
@@ -106,6 +108,7 @@ def test_processed_dataset_type(mocker):
         'processing': 'processed',
         'processing_type': 'hubmap',
         'uuid': '22684b9011fc5aea5cb3f89670a461e8',
+        'soft_assaytype': 'salmon_rnaseq_sciseq',
         'vitessce-hints': [
             "is_sc",
             "rna"
@@ -233,6 +236,7 @@ def test_transform_image_pyramid(mocker):
         'uuid': '69c70762689b20308bb049ac49653342',
         'vitessce-hints': [],
         'visualization': True,
+        "soft_assaytype": "PAS",
         'entity_type': 'Dataset',
     }
 

--- a/src/hubmap_translation/addl_index_transformations/portal/tests/test_transform.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/tests/test_transform.py
@@ -115,6 +115,7 @@ expected_output_doc = {'analyte_class': 'RNA',
                        '["http://purl.obolibrary.org/obo/UBERON_0001157"]}',
                        'status': 'New',
                        'uuid': '69c70762689b20308bb049ac49653342',
+                       'soft_assaytype': 'salmon_rnaseq_10x',
                        'vitessce-hints': ['is_sc', 'rna'],
                        'visualization': True,
                        }
@@ -137,6 +138,7 @@ def mock_response(response_to_mock, status_code=200, text='Logger call requires 
 def mock_soft_assay(uuid=None, headers=None):
     return mock_response({'assaytype': 'salmon_rnaseq_10x',
                           'contains-pii': False,
+                          'pipeline-shorthand': 'Salmon',
                           'description': 'scRNA-seq (10x Genomics) [Salmon]',
                           'primary': False,
                           'vitessce-hints': ['is_sc', 'rna']})


### PR DESCRIPTION
- Adds `soft_assaytype` to the document so we no longer have to call the ingest-api from portal-ui or portal-visualization.
- Tries to get the `pipeline` from the `pipeline-shorthand` instead of depending on regex.