### PR TITLE
Removed several misc basicconfig definitions for logging. Basicconfig…

### DIFF
--- a/src/hubmap_translation/addl_index_transformations/portal/add_assay_details.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/add_assay_details.py
@@ -9,8 +9,6 @@ from hubmap_translation.addl_index_transformations.portal.utils import (
     _log_transformation_error
 )
 
-logging.basicConfig(format='[%(asctime)s] %(levelname)s in %(module)s: %(message)s', level=logging.DEBUG,
-                    datefmt='%Y-%m-%d %H:%M:%S')
 logger = logging.getLogger(__name__)
 
 

--- a/src/hubmap_translation/addl_index_transformations/portal/utils.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/utils.py
@@ -1,7 +1,5 @@
 import logging
 
-logging.basicConfig(format='[%(asctime)s] %(levelname)s in %(module)s: %(message)s', level=logging.DEBUG,
-                    datefmt='%Y-%m-%d %H:%M:%S')
 logger = logging.getLogger(__name__)
 
 

--- a/src/hubmap_translation/debug.py
+++ b/src/hubmap_translation/debug.py
@@ -14,7 +14,6 @@ if __name__ == "__main__":
     if len(paths) == 0:
         print('Provide paths to JSON or YAML files as arguments')
         sys.exit(1)
-    logging.basicConfig(level=logging.DEBUG)
     for path in paths:
         doc = load_yaml(Path(path).read_text())
         new_name = f'{path}.transformed.yaml'

--- a/src/hubmap_translator.py
+++ b/src/hubmap_translator.py
@@ -25,8 +25,6 @@ from opensearch_helper_functions import *
 from translator.tranlation_helper_functions import *
 from translator.translator_interface import TranslatorInterface
 
-logging.basicConfig(format='[%(asctime)s] %(levelname)s in %(module)s: %(message)s', level=logging.DEBUG,
-                    datefmt='%Y-%m-%d %H:%M:%S')
 logger = logging.getLogger(__name__)
 
 # This list contains fields that are added to the top-level at index runtime


### PR DESCRIPTION
… affects the root logging object and cannot be redefined. If any of these are hit before the main one in search-adaptor, it'll prevent us from making a configurable debug mode.