### PR TITLE
Flip from git install of portal-visualization to pip install

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -5,7 +5,7 @@ jsonschema==4.23.0
 requests==2.32.4
 PyYAML==6.0.3
 
-git+https://github.com/hubmapconsortium/portal-visualization.git@0.4.18#egg=portal-visualization
+portal-visualization==0.4.20
 
 # Use the published package from PyPI as default
 # Use the branch name of commons from github for testing new changes made in commons from different branch


### PR DESCRIPTION
Flip from git install of portal-visualization 0.4.18 to pip installation pinned to version 0.4.20.