### PR TITLE
NickAkhmetov/CAT-1445 Mark image pyramid descendants as having visualization (not just the parent)

### DIFF
--- a/src/hubmap_translation/addl_index_transformations/portal/add_assay_details.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/add_assay_details.py
@@ -142,6 +142,15 @@ def _add_pipeline(doc, assay_details):
         doc['pipeline'] = pipeline.group()
 
 
+def _set_soft_assaytype(doc, assay_details):
+    if soft_assaytype := assay_details.get('assaytype'):
+        doc['soft_assaytype'] = soft_assaytype
+    doc['assay_display_name'] = [assay_details.get('description')]
+    # Remove once the portal-ui has transitioned to use assay_display_name.
+    doc['mapped_data_types'] = [assay_details.get('description')]
+    doc['vitessce-hints'] = assay_details.get('vitessce-hints')
+
+
 def add_assay_details(doc, transformation_resources):
     if 'dataset_type' in doc:
         assay_details = _get_assay_details(doc, transformation_resources)
@@ -151,14 +160,7 @@ def add_assay_details(doc, transformation_resources):
 
         _add_dataset_categories(doc, assay_details)
         _add_pipeline(doc, assay_details)
-
-        if soft_assaytype := assay_details.get('assaytype'):
-            doc['soft_assaytype'] = soft_assaytype
-        # Preserve the previous shape of mapped_data_types.
-        doc['assay_display_name'] = [assay_details.get('description')]
-        # Remove once the portal-ui has transitioned to use assay_display_name.
-        doc['mapped_data_types'] = [assay_details.get('description')]
-        doc['vitessce-hints'] = assay_details.get('vitessce-hints')
+        _set_soft_assaytype(doc, assay_details)
 
         error_msg = assay_details.get('error')
         if error_msg:
@@ -199,8 +201,7 @@ def add_assay_details(doc, transformation_resources):
             for descendant in descendants:
                 soft_assay_info = get_assay_type_for_descendants(descendant)
 
-                descendant['soft_assaytype'] = soft_assay_info.get('assaytype')
-                descendant['vitessce-hints'] = soft_assay_info.get('vitessce-hints', [])
+                _set_soft_assaytype(descendant, soft_assay_info)
 
                 if has_visualization(descendant, get_assay_type_for_descendants, parent_uuid):
                     doc['visualization'] = True

--- a/src/hubmap_translation/addl_index_transformations/portal/tests/test_assay_details.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/tests/test_assay_details.py
@@ -212,10 +212,14 @@ def test_transform_image_pyramid_parent(mocker):
         mock_image_pyramid_parent(),
         # request to get descendants of parent entity
         mock_image_pyramid_descendants(),
-        # request to get assay details of descendant entity
+        # request to get assay details of first descendant (uuid ending in 4919)
         mock_image_pyramid_support(),
         # portal-visualization re-requests parent entity details
         # to determine which type of image pyramid it is
+        mock_image_pyramid_parent(),
+        # request to get assay details of second descendant (uuid ending in 4918)
+        mock_image_pyramid_support(),
+        # portal-visualization re-requests parent entity details again
         mock_image_pyramid_parent(),
     ])
     image_pyramid_input_doc = {


### PR DESCRIPTION
There are cases on the portal where image pyramids on the dataset detail page are missing the `visualization` tag in the table of contents, e.g. https://portal.hubmapconsortium.org/browse/dataset/c9a15ae1d3afcfdb852004d0c714416e

Setting aside the broken Kaggle segmentation visualizations, the segmentation mask descended from this dataset is also missing the visualization part of its table of contents entry:

<img width="308" height="925" alt="image" src="https://github.com/user-attachments/assets/f7cb87f1-b91c-4750-a378-28b21603b1b4" />

Since that table of contents entry is populated based off of the presence of the `visualization` value, this PR adjusts that value to be set to `True` for both the main doc and any visualizeable descendants.

The `break` at the end of the if statement is removed to account for cases where there are multiple visualizable descendants, so that each of them gets the flag properly set.