### PR TITLE
NickAkhmetov/CAT-1488 Add logic to handle `has_visualization` for segmentation mask epics

### DIFF
--- a/src/hubmap_translation/addl_index_transformations/portal/add_assay_details.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/add_assay_details.py
@@ -203,6 +203,23 @@ def add_assay_details(doc, transformation_resources):
 
                 _set_soft_assaytype(descendant, soft_assay_info)
 
-                if has_visualization(descendant, get_assay_type_for_descendants, parent_uuid):
-                    doc['visualization'] = True
-                    descendant['visualization'] = True
+                # Determine epic_uuid for segmentation masks
+                # epic_uuid only gets set if the descendant has segmentation_mask/epic hint
+                epic_uuid = None
+                descendant_hints = descendant.get("vitessce-hints", [])
+
+                if (
+                    "segmentation_mask" in descendant_hints
+                    and "epic" in descendant_hints
+                    and descendant.get("status") != "Error"
+                ):
+                    epic_uuid = descendant.get("uuid")
+
+                if has_visualization(
+                    descendant,
+                    get_assay_type_for_descendants,
+                    parent=parent_uuid,
+                    epic_uuid=epic_uuid,
+                ):
+                    doc["visualization"] = True
+                    descendant["visualization"] = True


### PR DESCRIPTION
This PR adjusts `add_assay_details` to appropriately set the `visualization` value for segmentation mask EPICs, mirroring the logic on the front-end: https://github.com/hubmapconsortium/portal-ui/blob/main/context/app/routes_browse.py#L145-L152