### PR TITLE
Derek furst/optimize generate doc

### DIFF
--- a/src/hubmap_translator.py
+++ b/src/hubmap_translator.py
@@ -1263,7 +1263,7 @@ class Translator(TranslatorInterface):
             logger.error(e)
 
     def translate_collection(self, entity, reindex=False):
-        if isinstance(entity, str)
+        if isinstance(entity, str):
             # This is a legacy version which passes in a uuid for an entity rather than the 
             # entity itself. This is most often used by a full reindex
             entity = self.call_entity_api(entity_id=entity, endpoint_base='documents')
@@ -1311,11 +1311,11 @@ class Translator(TranslatorInterface):
                                                      , es_index=private_index
                                                      , delete_existing_doc_first=reindex)
 
-            logger.info(f"Finished executing translate_collection() for {entity_id}")
+            logger.info(f"Finished executing translate_collection() for {entity.get('uuid')}")
         except requests.exceptions.RequestException as e:
             logger.exception(e)
             # Log the error and will need fix later and reindex, rather than sys.exit()
-            logger.error(f"translate_collection() failed to get collection of uuid: {entity_id} via entity-api")
+            logger.error(f"translate_collection() failed to get collection of uuid: {entity.get('uuid')} via entity-api")
         except Exception as e:
             logger.error(e)
 

--- a/src/hubmap_translator.py
+++ b/src/hubmap_translator.py
@@ -1234,6 +1234,10 @@ class Translator(TranslatorInterface):
 
     # When indexing, Upload WILL NEVER BE PUBLIC
     def translate_upload(self, entity, reindex=False):
+        if isinstance(entity, str):
+            # This is a legacy version which passes in a uuid for an entity rather than the 
+            # entity itself. This is most often used by a full reindex
+            entity = self.call_entity_api(entity_id=entity, endpoint_base='documents')
         try:
             logger.info(f"Start executing translate_upload() for {entity.get('uuid')}")
 
@@ -1254,11 +1258,15 @@ class Translator(TranslatorInterface):
                                                     , es_index=default_private_index
                                                     , delete_existing_doc_first=reindex)
 
-            logger.info(f"Finished executing translate_upload() for {entity_id}")
+            logger.info(f"Finished executing translate_upload() for {entity.get('uuid')}")
         except Exception as e:
             logger.error(e)
 
     def translate_collection(self, entity, reindex=False):
+        if isinstance(entity, str)
+            # This is a legacy version which passes in a uuid for an entity rather than the 
+            # entity itself. This is most often used by a full reindex
+            entity = self.call_entity_api(entity_id=entity, endpoint_base='documents')
         logger.info(f"Start executing translate_collection() for {entity.get('uuid')}")
 
         # The entity-api returns public collection with a list of connected public/published datasets, for either


### PR DESCRIPTION
This fix addresses an incompatibility between the translate_all workflow and the reworked individual reindex workflow. Translate_uploads|collections used to take an id, then superfluously call entity to get the whole dict. Now we just accept the whole dict, but this broke the calls made from the translate-all workflow. in order to preserve the legacy code, I modified the translate_upload and translate_collection to accept either the id itself, or the whole entity. Changed some logs that referenced the entity id to go along with that