### PR TITLE
Add multi-donor demographics transformations

### DIFF
--- a/src/hubmap_translation/addl_index_transformations/portal/__init__.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/__init__.py
@@ -15,6 +15,9 @@ from hubmap_translation.addl_index_transformations.portal.translate import (
 from hubmap_translation.addl_index_transformations.portal.add_counts import (
     add_counts
 )
+from hubmap_translation.addl_index_transformations.portal.add_donor_demographics import (
+    add_donor_demographics
+)
 from hubmap_translation.addl_index_transformations.portal.add_partonomy import (
     add_partonomy
 )
@@ -77,6 +80,8 @@ def transform(doc, transformation_resources, batch_id='unspecified'):
         return None
     sort_files(doc_copy)
     add_counts(doc_copy)
+    # Depends on donor mapped_metadata produced by translate().
+    add_donor_demographics(doc_copy)
     add_is_integrated(doc_copy)
     add_partonomy(doc_copy, organ_map)
     reset_entity_type(doc_copy)

--- a/src/hubmap_translation/addl_index_transformations/portal/add_donor_demographics.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/add_donor_demographics.py
@@ -12,9 +12,14 @@ def add_donor_demographics(doc):
     into a single top-level "donor_demographics" object, so multi-donor entities
     can be accurately filtered and displayed (rather than only reflecting donor #0).
 
-    Each donor already has a "mapped_metadata" dict (produced by translate.py) that
-    follows the convention: numeric fields are "<field>_value"/"<field>_unit" lists,
-    and everything else is a list of categorical values.
+    Each donor already has a "mapped_metadata" dict (produced by
+    translate._donor_metadata_map). There a numeric field is stored as
+    "<field>_value" + "<field>_unit" lists when it has units, but under the bare
+    "<field>" key (a list of numbers) when it does not; categorical fields are stored
+    under the bare "<field>" key as a list of terms. We therefore treat a
+    "<field>_value" key -- or a bare key whose values are all numeric -- as numeric
+    (producing a range-filterable "<field>_value" array plus a min/max/mean "<field>"
+    stats object), and any other bare key as a categorical set.
 
     Categorical fields become a deduplicated, sorted set across all donors:
 
@@ -48,6 +53,22 @@ def add_donor_demographics(doc):
      'age_unit': ['years'],
      'age_value': [30.0, 50.0, 70.0]}
 
+    A numeric field with no units is stored by translate under the bare "<field>"
+    key; it is still normalized into a range-filterable array plus stats:
+
+    >>> doc = {
+    ...     'entity_type': 'Dataset',
+    ...     'donors': [
+    ...         {'mapped_metadata': {'age': [40.0]}},
+    ...         {'mapped_metadata': {'age': [60.0]}},
+    ...     ],
+    ... }
+    >>> add_donor_demographics(doc)
+    >>> doc['donor_demographics']['age_value']
+    [40.0, 60.0]
+    >>> doc['donor_demographics']['age']
+    {'min': 40.0, 'max': 60.0, 'mean': 50.0}
+
     When no "donors" list is present, it falls back to the single "donor":
 
     >>> doc = {'entity_type': 'Dataset', 'donor': {'mapped_metadata': {'sex': ['Male']}}}
@@ -78,20 +99,44 @@ def _aggregate_donor_demographics(donors):
         for key, values in mapped_metadata.items():
             collected[key].extend(values if isinstance(values, list) else [values])
 
-    demographics = {}
+    # Sort the pooled keys into numeric values, units, and categorical sets. A field
+    # may surface as "<field>_value"/"<field>_unit" (had units) or as a bare "<field>"
+    # numeric list (no units), so both must funnel into the numeric bucket.
+    numeric_values = defaultdict(list)
+    units = defaultdict(set)
+    categorical = {}
     for key, values in collected.items():
-        if key.endswith('_value'):
-            numeric = [v for v in values if isinstance(v, (int, float))]
-            if not numeric:
-                continue
-            # Keep the array (range-filterable) and add display stats.
-            demographics[key] = sorted(set(numeric))
-            demographics[key[:-len('_value')]] = {
-                'min': min(numeric),
-                'max': max(numeric),
-                'mean': round(sum(numeric) / len(numeric), 2),
-            }
+        if key.endswith('_unit'):
+            units[key[:-len('_unit')]].update(values)
+        elif key.endswith('_value'):
+            numeric_values[key[:-len('_value')]].extend(_numbers(values))
+        elif _all_numbers(values):
+            numeric_values[key].extend(_numbers(values))
         else:
-            # Units and categorical fields: deduplicated, sorted set.
-            demographics[key] = sorted(set(values))
+            categorical[key] = values
+
+    demographics = {}
+    for field, nums in numeric_values.items():
+        if not nums:
+            continue
+        # Keep the array (range-filterable) and add display stats.
+        demographics[f'{field}_value'] = sorted(set(nums))
+        demographics[field] = {
+            'min': min(nums),
+            'max': max(nums),
+            'mean': round(sum(nums) / len(nums), 2),
+        }
+        if units.get(field):
+            demographics[f'{field}_unit'] = sorted(units[field])
+    for field, values in categorical.items():
+        demographics[field] = sorted(set(values))
     return demographics
+
+
+def _numbers(values):
+    # bool is a subclass of int; exclude it so booleans aren't treated as numeric.
+    return [v for v in values if isinstance(v, (int, float)) and not isinstance(v, bool)]
+
+
+def _all_numbers(values):
+    return bool(values) and len(_numbers(values)) == len(values)

--- a/src/hubmap_translation/addl_index_transformations/portal/add_donor_demographics.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/add_donor_demographics.py
@@ -69,9 +69,9 @@ def add_donor_demographics(doc):
     >>> doc['donor_demographics']['age']
     {'min': 40.0, 'max': 60.0, 'mean': 50.0}
 
-    When no "donors" list is present, it falls back to the single "donor":
+    A single-donor entity is simply a "donors" list of length one:
 
-    >>> doc = {'entity_type': 'Dataset', 'donor': {'mapped_metadata': {'sex': ['Male']}}}
+    >>> doc = {'entity_type': 'Dataset', 'donors': [{'mapped_metadata': {'sex': ['Male']}}]}
     >>> add_donor_demographics(doc)
     >>> doc['donor_demographics']
     {'sex': ['Male']}
@@ -85,7 +85,7 @@ def add_donor_demographics(doc):
     '''
     if doc.get('entity_type') not in DEMOGRAPHIC_ENTITY_TYPES:
         return
-    donors = doc.get('donors') or ([doc['donor']] if 'donor' in doc else [])
+    donors = doc.get('donors', [])
     if not donors:
         return
     doc['donor_demographics'] = _aggregate_donor_demographics(donors)

--- a/src/hubmap_translation/addl_index_transformations/portal/add_donor_demographics.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/add_donor_demographics.py
@@ -1,0 +1,97 @@
+from collections import defaultdict
+
+# Entity types that carry one or more donors and should get an aggregated
+# "donor_demographics" object. (Donor entities use their own top-level
+# "mapped_metadata" instead, so they are intentionally excluded.)
+DEMOGRAPHIC_ENTITY_TYPES = {'Dataset', 'Sample', 'Publication'}
+
+
+def add_donor_demographics(doc):
+    '''
+    Aggregate donor demographics across *all* donors of a Dataset/Sample/Publication
+    into a single top-level "donor_demographics" object, so multi-donor entities
+    can be accurately filtered and displayed (rather than only reflecting donor #0).
+
+    Each donor already has a "mapped_metadata" dict (produced by translate.py) that
+    follows the convention: numeric fields are "<field>_value"/"<field>_unit" lists,
+    and everything else is a list of categorical values.
+
+    Categorical fields become a deduplicated, sorted set across all donors:
+
+    >>> from pprint import pprint
+    >>> doc = {
+    ...     'entity_type': 'Dataset',
+    ...     'donors': [
+    ...         {'mapped_metadata': {'sex': ['Male'], 'race': ['White']}},
+    ...         {'mapped_metadata': {'sex': ['Female'], 'race': ['White', 'Asian']}},
+    ...     ],
+    ... }
+    >>> add_donor_demographics(doc)
+    >>> pprint(doc['donor_demographics'])
+    {'race': ['Asian', 'White'], 'sex': ['Female', 'Male']}
+
+    Numeric fields keep the sorted set of all donors' values (so an ES range query
+    matches if *any* donor falls in range) plus a min/max/mean stats object for
+    display; units are collected uniquely:
+
+    >>> doc = {
+    ...     'entity_type': 'Dataset',
+    ...     'donors': [
+    ...         {'mapped_metadata': {'age_value': [30.0], 'age_unit': ['years']}},
+    ...         {'mapped_metadata': {'age_value': [70.0], 'age_unit': ['years']}},
+    ...         {'mapped_metadata': {'age_value': [50.0], 'age_unit': ['years']}},
+    ...     ],
+    ... }
+    >>> add_donor_demographics(doc)
+    >>> pprint(doc['donor_demographics'])
+    {'age': {'max': 70.0, 'mean': 50.0, 'min': 30.0},
+     'age_unit': ['years'],
+     'age_value': [30.0, 50.0, 70.0]}
+
+    When no "donors" list is present, it falls back to the single "donor":
+
+    >>> doc = {'entity_type': 'Dataset', 'donor': {'mapped_metadata': {'sex': ['Male']}}}
+    >>> add_donor_demographics(doc)
+    >>> doc['donor_demographics']
+    {'sex': ['Male']}
+
+    Entities of other types, or with no donor info, are left untouched:
+
+    >>> doc = {'entity_type': 'Donor', 'mapped_metadata': {'sex': ['Male']}}
+    >>> add_donor_demographics(doc)
+    >>> 'donor_demographics' in doc
+    False
+    '''
+    if doc.get('entity_type') not in DEMOGRAPHIC_ENTITY_TYPES:
+        return
+    donors = doc.get('donors') or ([doc['donor']] if 'donor' in doc else [])
+    if not donors:
+        return
+    doc['donor_demographics'] = _aggregate_donor_demographics(donors)
+
+
+def _aggregate_donor_demographics(donors):
+    # Pool each mapped_metadata key's values across every donor.
+    collected = defaultdict(list)
+    for donor in donors:
+        mapped_metadata = donor.get('mapped_metadata') or {}
+        for key, values in mapped_metadata.items():
+            collected[key].extend(values if isinstance(values, list) else [values])
+
+    demographics = {}
+    for key, values in collected.items():
+        if key.endswith('_value'):
+            numeric = [v for v in values if isinstance(v, (int, float))]
+            if not numeric:
+                continue
+            # Keep the array (range-filterable) and add display stats.
+            demographics[key] = sorted(set(numeric))
+            demographics[key[:-len('_value')]] = {
+                'min': min(numeric),
+                'max': max(numeric),
+                'mean': round(sum(numeric) / len(numeric), 2),
+            }
+        else:
+            # Units and categorical fields: deduplicated, sorted set.
+            demographics[key] = sorted(set(values))
+    return demographics

--- a/src/hubmap_translation/addl_index_transformations/portal/tests/test_add_donor_demographics.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/tests/test_add_donor_demographics.py
@@ -81,19 +81,39 @@ def test_mean_is_rounded():
     assert doc['donor_demographics']['age']['mean'] == 41.33
 
 
-def test_duplicate_numeric_values_are_deduped_in_array_but_counted_in_mean():
+def test_numeric_field_without_units_is_normalized_to_value_array_and_stats():
+    # translate stores a unit-less numeric field under the bare "<field>" key (a float
+    # list), not "<field>_value". It must still become a range-filterable array + stats.
     doc = {
         'entity_type': 'Dataset',
         'donors': [
-            _donor({'age_value': [40.0]}),
-            _donor({'age_value': [40.0]}),
-            _donor({'age_value': [70.0]}),
+            _donor({'age': [40.0]}),
+            _donor({'age': [40.0]}),
+            _donor({'age': [70.0]}),
+        ],
+    }
+    add_donor_demographics(doc)
+    demographics = doc['donor_demographics']
+    # Duplicate values are deduped in the array but still counted in the mean.
+    assert demographics['age_value'] == [40.0, 70.0]
+    assert demographics['age'] == {'min': 40.0, 'max': 70.0, 'mean': 50.0}
+    assert 'age_unit' not in demographics
+
+
+def test_same_field_with_and_without_units_merges():
+    # One donor reports units, another does not -> both values feed one numeric field.
+    doc = {
+        'entity_type': 'Dataset',
+        'donors': [
+            _donor({'age_value': [40.0], 'age_unit': ['years']}),
+            _donor({'age': [70.0]}),
         ],
     }
     add_donor_demographics(doc)
     demographics = doc['donor_demographics']
     assert demographics['age_value'] == [40.0, 70.0]
-    assert demographics['age'] == {'min': 40.0, 'max': 70.0, 'mean': 50.0}
+    assert demographics['age'] == {'min': 40.0, 'max': 70.0, 'mean': 55.0}
+    assert demographics['age_unit'] == ['years']
 
 
 def test_falls_back_to_single_donor_when_no_donors_list():

--- a/src/hubmap_translation/addl_index_transformations/portal/tests/test_add_donor_demographics.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/tests/test_add_donor_demographics.py
@@ -1,0 +1,146 @@
+from hubmap_translation.addl_index_transformations.portal.add_donor_demographics import (
+    add_donor_demographics,
+)
+
+
+def _donor(mapped_metadata):
+    return {'mapped_metadata': mapped_metadata}
+
+
+def test_aggregates_categorical_and_numeric_across_donors():
+    doc = {
+        'entity_type': 'Dataset',
+        'donors': [
+            _donor({
+                'sex': ['Male'],
+                'race': ['White'],
+                'age_value': [30.0],
+                'age_unit': ['years'],
+                'height_value': [180.0],
+                'height_unit': ['cm'],
+                'body_mass_index_value': [22.0],
+                'body_mass_index_unit': ['kg/m^2'],
+            }),
+            _donor({
+                'sex': ['Female'],
+                'race': ['White', 'Asian'],
+                'age_value': [70.0],
+                'age_unit': ['years'],
+                'height_value': [160.0],
+                'height_unit': ['cm'],
+                'body_mass_index_value': [30.0],
+                'body_mass_index_unit': ['kg/m^2'],
+            }),
+            _donor({
+                'sex': ['Female'],
+                'race': ['Black or African American'],
+                'age_value': [50.0],
+                'age_unit': ['years'],
+                'height_value': [170.0],
+                'height_unit': ['cm'],
+                'body_mass_index_value': [26.0],
+                'body_mass_index_unit': ['kg/m^2'],
+            }),
+        ],
+    }
+
+    add_donor_demographics(doc)
+    demographics = doc['donor_demographics']
+
+    # Categorical fields: deduplicated, sorted union across all donors.
+    assert demographics['sex'] == ['Female', 'Male']
+    assert demographics['race'] == ['Asian', 'Black or African American', 'White']
+
+    # Numeric fields: sorted array of every value (range-filterable) ...
+    assert demographics['age_value'] == [30.0, 50.0, 70.0]
+    assert demographics['height_value'] == [160.0, 170.0, 180.0]
+    assert demographics['body_mass_index_value'] == [22.0, 26.0, 30.0]
+
+    # ... plus a min/max/mean stats object for display.
+    assert demographics['age'] == {'min': 30.0, 'max': 70.0, 'mean': 50.0}
+    assert demographics['height'] == {'min': 160.0, 'max': 180.0, 'mean': 170.0}
+    assert demographics['body_mass_index'] == {'min': 22.0, 'max': 30.0, 'mean': 26.0}
+
+    # Units collected uniquely.
+    assert demographics['age_unit'] == ['years']
+    assert demographics['height_unit'] == ['cm']
+    assert demographics['body_mass_index_unit'] == ['kg/m^2']
+
+
+def test_mean_is_rounded():
+    doc = {
+        'entity_type': 'Dataset',
+        'donors': [
+            _donor({'age_value': [40.0], 'age_unit': ['years']}),
+            _donor({'age_value': [41.0], 'age_unit': ['years']}),
+            _donor({'age_value': [43.0], 'age_unit': ['years']}),
+        ],
+    }
+    add_donor_demographics(doc)
+    # (40 + 41 + 43) / 3 = 41.333... -> rounded to 2 dp.
+    assert doc['donor_demographics']['age']['mean'] == 41.33
+
+
+def test_duplicate_numeric_values_are_deduped_in_array_but_counted_in_mean():
+    doc = {
+        'entity_type': 'Dataset',
+        'donors': [
+            _donor({'age_value': [40.0]}),
+            _donor({'age_value': [40.0]}),
+            _donor({'age_value': [70.0]}),
+        ],
+    }
+    add_donor_demographics(doc)
+    demographics = doc['donor_demographics']
+    assert demographics['age_value'] == [40.0, 70.0]
+    assert demographics['age'] == {'min': 40.0, 'max': 70.0, 'mean': 50.0}
+
+
+def test_falls_back_to_single_donor_when_no_donors_list():
+    doc = {
+        'entity_type': 'Dataset',
+        'donor': _donor({'sex': ['Male'], 'race': ['White']}),
+    }
+    add_donor_demographics(doc)
+    assert doc['donor_demographics'] == {'race': ['White'], 'sex': ['Male']}
+
+
+def test_donors_list_takes_precedence_over_single_donor():
+    doc = {
+        'entity_type': 'Dataset',
+        'donor': _donor({'sex': ['Male']}),
+        'donors': [
+            _donor({'sex': ['Male']}),
+            _donor({'sex': ['Female']}),
+        ],
+    }
+    add_donor_demographics(doc)
+    assert doc['donor_demographics']['sex'] == ['Female', 'Male']
+
+
+def test_applies_to_sample_and_publication():
+    for entity_type in ('Sample', 'Publication'):
+        doc = {
+            'entity_type': entity_type,
+            'donors': [_donor({'sex': ['Female']})],
+        }
+        add_donor_demographics(doc)
+        assert doc['donor_demographics'] == {'sex': ['Female']}
+
+
+def test_empty_metadata_produces_empty_demographics():
+    doc = {'entity_type': 'Dataset', 'donor': _donor({})}
+    add_donor_demographics(doc)
+    assert doc['donor_demographics'] == {}
+
+
+def test_skips_non_demographic_entity_types():
+    doc = {'entity_type': 'Donor', 'mapped_metadata': {'sex': ['Male']}}
+    add_donor_demographics(doc)
+    assert 'donor_demographics' not in doc
+
+
+def test_skips_when_no_donor_present():
+    doc = {'entity_type': 'Dataset'}
+    add_donor_demographics(doc)
+    assert 'donor_demographics' not in doc

--- a/src/hubmap_translation/addl_index_transformations/portal/tests/test_add_donor_demographics.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/tests/test_add_donor_demographics.py
@@ -116,19 +116,19 @@ def test_same_field_with_and_without_units_merges():
     assert demographics['age_unit'] == ['years']
 
 
-def test_falls_back_to_single_donor_when_no_donors_list():
+def test_single_donor_is_a_donors_list_of_one():
     doc = {
         'entity_type': 'Dataset',
-        'donor': _donor({'sex': ['Male'], 'race': ['White']}),
+        'donors': [_donor({'sex': ['Male'], 'race': ['White']})],
     }
     add_donor_demographics(doc)
     assert doc['donor_demographics'] == {'race': ['White'], 'sex': ['Male']}
 
 
-def test_donors_list_takes_precedence_over_single_donor():
+def test_aggregates_only_from_donors_list_ignoring_single_donor_key():
     doc = {
         'entity_type': 'Dataset',
-        'donor': _donor({'sex': ['Male']}),
+        'donor': _donor({'sex': ['Other']}),  # legacy key must be ignored
         'donors': [
             _donor({'sex': ['Male']}),
             _donor({'sex': ['Female']}),
@@ -149,7 +149,7 @@ def test_applies_to_sample_and_publication():
 
 
 def test_empty_metadata_produces_empty_demographics():
-    doc = {'entity_type': 'Dataset', 'donor': _donor({})}
+    doc = {'entity_type': 'Dataset', 'donors': [_donor({})]}
     add_donor_demographics(doc)
     assert doc['donor_demographics'] == {}
 
@@ -160,7 +160,7 @@ def test_skips_non_demographic_entity_types():
     assert 'donor_demographics' not in doc
 
 
-def test_skips_when_no_donor_present():
-    doc = {'entity_type': 'Dataset'}
-    add_donor_demographics(doc)
-    assert 'donor_demographics' not in doc
+def test_skips_when_donors_list_is_empty_or_absent():
+    for doc in ({'entity_type': 'Dataset'}, {'entity_type': 'Dataset', 'donors': []}):
+        add_donor_demographics(doc)
+        assert 'donor_demographics' not in doc

--- a/src/hubmap_translation/addl_index_transformations/portal/tests/test_transform.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/tests/test_transform.py
@@ -99,6 +99,8 @@ expected_output_doc = {
             ]
         },
     },
+    # Aggregated across all donors; here only the single "donor" (no "donors" list).
+    "donor_demographics": {"sex": ["Male"]},
     "entity_type": "Dataset",
     "files": [
         {

--- a/src/hubmap_translation/addl_index_transformations/portal/tests/test_transform.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/tests/test_transform.py
@@ -34,6 +34,19 @@ input_doc = {
             ]
         }
     },
+    "donors": [
+        {
+            "metadata": {
+                "organ_donor_data": [
+                    {
+                        "data_type": "Nominal",
+                        "grouping_concept_preferred_term": "Sex",
+                        "preferred_term": "Male",
+                    }
+                ]
+            }
+        }
+    ],
     "files": [
         {
             "description": "OME-TIFF pyramid file",
@@ -99,7 +112,21 @@ expected_output_doc = {
             ]
         },
     },
-    # Aggregated across all donors; here only the single "donor" (no "donors" list).
+    "donors": [
+        {
+            "mapped_metadata": {"sex": ["Male"]},
+            "metadata": {
+                "organ_donor_data": [
+                    {
+                        "data_type": "Nominal",
+                        "grouping_concept_preferred_term": "Sex",
+                        "preferred_term": "Male",
+                    }
+                ]
+            },
+        }
+    ],
+    # Aggregated across every donor in the "donors" list.
     "donor_demographics": {"sex": ["Male"]},
     "entity_type": "Dataset",
     "files": [


### PR DESCRIPTION
This PR:

* Adds `donor_demographics` for datasets, samples, and publications (all entities with previously associated `donor.mapped_metadata`
* This calculation relies on `donors` and falls back to `donor` in case `donors` is not available
* For all fields, the `{fieldName}_value` key includes all unique values
* For numeric fields, a min/max/mean is calculated