### PR TITLE
NickAkhmetov/Normalize ages from months to years in donor demographics and update tests accordingly

### DIFF
--- a/src/hubmap_translation/addl_index_transformations/portal/add_donor_demographics.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/add_donor_demographics.py
@@ -53,6 +53,22 @@ def add_donor_demographics(doc):
      'age_unit': ['years'],
      'age_value': [30.0, 50.0, 70.0]}
 
+    Ages reported in months are normalized to years (divided by 12) so they are
+    comparable across donors; the unit is relabeled accordingly:
+
+    >>> doc = {
+    ...     'entity_type': 'Dataset',
+    ...     'donors': [
+    ...         {'mapped_metadata': {'age_value': [30.0], 'age_unit': ['years']}},
+    ...         {'mapped_metadata': {'age_value': [24.0], 'age_unit': ['months']}},
+    ...     ],
+    ... }
+    >>> add_donor_demographics(doc)
+    >>> pprint(doc['donor_demographics'])
+    {'age': {'max': 30.0, 'mean': 16.0, 'min': 2.0},
+     'age_unit': ['years'],
+     'age_value': [2.0, 30.0]}
+
     A numeric field with no units is stored by translate under the bare "<field>"
     key; it is still normalized into a range-filterable array plus stats:
 
@@ -95,7 +111,9 @@ def _aggregate_donor_demographics(donors):
     # Pool each mapped_metadata key's values across every donor.
     collected = defaultdict(list)
     for donor in donors:
-        mapped_metadata = donor.get('mapped_metadata') or {}
+        # Normalize ages to years before pooling, while each donor's parallel
+        # age_value/age_unit lists are still aligned.
+        mapped_metadata = _ages_in_years(donor.get('mapped_metadata') or {})
         for key, values in mapped_metadata.items():
             collected[key].extend(values if isinstance(values, list) else [values])
 
@@ -131,6 +149,34 @@ def _aggregate_donor_demographics(donors):
     for field, values in categorical.items():
         demographics[field] = sorted(set(values))
     return demographics
+
+
+MONTHS_PER_YEAR = 12
+
+
+def _ages_in_years(mapped_metadata):
+    '''Return mapped_metadata with the donor's age expressed in years.
+
+    translate stores age as parallel "age_value"/"age_unit" lists; any value whose
+    unit is "months" is divided by 12 and its unit relabeled "years" so ages are
+    comparable across donors. A bare, unit-less "age" list can't be converted and is
+    assumed to already be in years.
+    '''
+    values = mapped_metadata.get('age_value')
+    units = mapped_metadata.get('age_unit')
+    if not values or not units:
+        return mapped_metadata
+
+    converted_values = []
+    converted_units = []
+    for value, unit in zip(values, units):
+        if _numbers([value]) and str(unit).lower() == 'months':
+            converted_values.append(round(value / MONTHS_PER_YEAR, 2))
+            converted_units.append('years')
+        else:
+            converted_values.append(value)
+            converted_units.append(unit)
+    return {**mapped_metadata, 'age_value': converted_values, 'age_unit': converted_units}
 
 
 def _numbers(values):

--- a/src/hubmap_translation/addl_index_transformations/portal/tests/test_add_donor_demographics.py
+++ b/src/hubmap_translation/addl_index_transformations/portal/tests/test_add_donor_demographics.py
@@ -116,6 +116,47 @@ def test_same_field_with_and_without_units_merges():
     assert demographics['age_unit'] == ['years']
 
 
+def test_age_in_months_is_converted_to_years():
+    doc = {
+        'entity_type': 'Dataset',
+        'donors': [_donor({'age_value': [30.0], 'age_unit': ['months']})],
+    }
+    add_donor_demographics(doc)
+    demographics = doc['donor_demographics']
+    # 30 months / 12 = 2.5 years; the unit is relabeled.
+    assert demographics['age_value'] == [2.5]
+    assert demographics['age'] == {'min': 2.5, 'max': 2.5, 'mean': 2.5}
+    assert demographics['age_unit'] == ['years']
+
+
+def test_mixed_age_units_are_normalized_to_years_before_aggregating():
+    # One donor in years, one in months, one infant in months -> all comparable in years.
+    doc = {
+        'entity_type': 'Dataset',
+        'donors': [
+            _donor({'age_value': [30.0], 'age_unit': ['years']}),
+            _donor({'age_value': [24.0], 'age_unit': ['months']}),
+            _donor({'age_value': [6.0], 'age_unit': ['months']}),
+        ],
+    }
+    add_donor_demographics(doc)
+    demographics = doc['donor_demographics']
+    # 24 months -> 2.0 years, 6 months -> 0.5 years.
+    assert demographics['age_value'] == [0.5, 2.0, 30.0]
+    assert demographics['age'] == {'min': 0.5, 'max': 30.0, 'mean': round((30 + 2 + 0.5) / 3, 2)}
+    assert demographics['age_unit'] == ['years']
+
+
+def test_age_unit_match_is_case_insensitive():
+    doc = {
+        'entity_type': 'Dataset',
+        'donors': [_donor({'age_value': [12.0], 'age_unit': ['Months']})],
+    }
+    add_donor_demographics(doc)
+    assert doc['donor_demographics']['age_value'] == [1.0]
+    assert doc['donor_demographics']['age_unit'] == ['years']
+
+
 def test_single_donor_is_a_donors_list_of_one():
     doc = {
         'entity_type': 'Dataset',


### PR DESCRIPTION
This PR standardizes month-based ages into years in the donor demographics fields. This will allow us to properly work with ages in search facets.

I noticed this issue when I inspected the Object x Analyte dataset on production; since it has a parent donor with an age indicated in months, the age on my local branch that uses the donor demographics field was shown in months instead of years.

This query surfaces the entities that will need to be reindexed with this change applied:

```
{
  "size": 10000,
  "_source": [
    "uuid", "hubmap_id", "entity_type",
    "donor_demographics.age_value",
    "donor_demographics.age_unit",
    "donor_demographics.age"
  ],
  "query": {
    "bool": {
      "filter": [
        { "terms": { "entity_type.keyword": ["Dataset", "Sample"] } },
        { "wildcard": { "donor_demographics.age_unit.keyword": { "value": "month*", "case_insensitive": true } } }
      ]
    }
  }
}
```